### PR TITLE
Link to user's profile in a generated changelog

### DIFF
--- a/Sources/GitBuddyCore/Models/ChangelogItem.swift
+++ b/Sources/GitBuddyCore/Models/ChangelogItem.swift
@@ -37,7 +37,7 @@ struct ChangelogItem {
             title += " ([#\(input.number)](\(htmlURL)))"
         }
         if let username = closedBy.username {
-            title += " via @\(username)"
+            title += " via [@\(username)](https://github.com/\(username))"
         }
         return title
     }

--- a/Tests/GitBuddyTests/Changelog/ChangelogProducerTests.swift
+++ b/Tests/GitBuddyTests/Changelog/ChangelogProducerTests.swift
@@ -37,7 +37,15 @@ final class ChangelogProducerTests: XCTestCase {
         Mocker.mockForIssueNumber(39)
         MockedShell.mockGITProject(organisation: "WeTransfer", repository: "Diagnostics")
         let changelog = try GitBuddy.run(arguments: ["GitBuddy", "changelog"], configuration: configuration)
-        XCTAssertEqual(changelog, "- Add charset utf-8 to html head ([#50](https://github.com/WeTransfer/Diagnostics/pull/50)) via @AvdLee\n- Get warning for file \'style.css\' after building ([#39](https://github.com/WeTransfer/Diagnostics/issues/39)) via @AvdLee")
+        XCTAssertEqual(
+            changelog,
+            """
+            - Add charset utf-8 to html head \
+            ([#50](https://github.com/WeTransfer/Diagnostics/pull/50)) via [@AvdLee](https://github.com/AvdLee)
+            - Get warning for file \'style.css\' after building \
+            ([#39](https://github.com/WeTransfer/Diagnostics/issues/39)) via [@AvdLee](https://github.com/AvdLee)
+            """
+        )
     }
 
     /// It should default to master branch.

--- a/Tests/GitBuddyTests/Models/ChangelogItemTests.swift
+++ b/Tests/GitBuddyTests/Models/ChangelogItemTests.swift
@@ -30,7 +30,7 @@ final class ChangelogItemTests: XCTestCase {
         let input = PullRequestsJSON.data(using: .utf8)!.mapJSON(to: [PullRequest].self).first!
         input.htmlURL = nil
         let item = ChangelogItem(input: input, closedBy: input)
-        XCTAssertEqual(item.title, "\(input.title!) via @AvdLee")
+        XCTAssertEqual(item.title, "\(input.title!) via [@AvdLee](https://github.com/AvdLee)")
     }
 
     /// It should fallback to the assignee if the user is nil for Pull Requests.
@@ -39,7 +39,10 @@ final class ChangelogItemTests: XCTestCase {
         input.user = nil
         input.htmlURL = nil
         let item = ChangelogItem(input: input, closedBy: input)
-        XCTAssertEqual(item.title, "\(input.title!) via @kairadiagne")
+        XCTAssertEqual(
+            item.title,
+            "\(input.title!) via [@kairadiagne](https://github.com/kairadiagne)"
+        )
     }
 
     /// It should combine the title, number and user.
@@ -47,7 +50,10 @@ final class ChangelogItemTests: XCTestCase {
         let input = MockChangelogInput(number: 1, title: UUID().uuidString, htmlURL: URL(string: "https://www.fakeurl.com")!)
         let closedBy = MockedPullRequest(username: "Henk")
         let item = ChangelogItem(input: input, closedBy: closedBy)
-        XCTAssertEqual(item.title, "\(input.title!) ([#1](https://www.fakeurl.com)) via @Henk")
+        XCTAssertEqual(
+            item.title,
+            "\(input.title!) ([#1](https://www.fakeurl.com)) via [@Henk](https://github.com/Henk)"
+        )
     }
 
 }

--- a/Tests/GitBuddyTests/Release/ReleaseProducerTests.swift
+++ b/Tests/GitBuddyTests/Release/ReleaseProducerTests.swift
@@ -52,8 +52,10 @@ final class ReleaseProducerTests: XCTestCase {
             XCTAssertEqual(parameters["tag_name"] as? String, "1.0.1")
             XCTAssertEqual(parameters["name"] as? String, "1.0.1")
             XCTAssertEqual(parameters["body"] as? String, """
-            - Add charset utf-8 to html head ([#50](https://github.com/WeTransfer/Diagnostics/pull/50)) via @AvdLee
-            - Get warning for file 'style.css' after building ([#39](https://github.com/WeTransfer/Diagnostics/issues/39)) via @AvdLee
+            - Add charset utf-8 to html head \
+            ([#50](https://github.com/WeTransfer/Diagnostics/pull/50)) via [@AvdLee](https://github.com/AvdLee)
+            - Get warning for file 'style.css' after building \
+            ([#39](https://github.com/WeTransfer/Diagnostics/issues/39)) via [@AvdLee](https://github.com/AvdLee)
             """)
             mockExpectation.fulfill()
         }
@@ -76,8 +78,10 @@ final class ReleaseProducerTests: XCTestCase {
 
         XCTAssertEqual(updatedChangelogContents, """
         ### 1.0.1
-        - Add charset utf-8 to html head ([#50](https://github.com/WeTransfer/Diagnostics/pull/50)) via @AvdLee
-        - Get warning for file \'style.css\' after building ([#39](https://github.com/WeTransfer/Diagnostics/issues/39)) via @AvdLee
+        - Add charset utf-8 to html head \
+        ([#50](https://github.com/WeTransfer/Diagnostics/pull/50)) via [@AvdLee](https://github.com/AvdLee)
+        - Get warning for file \'style.css\' after building \
+        ([#39](https://github.com/WeTransfer/Diagnostics/issues/39)) via [@AvdLee](https://github.com/AvdLee)
 
         \(existingChangelog)
         """)


### PR DESCRIPTION
In a generated changelog it would be great if usernames also linked to corresponding GitHub user profiles. The tests are modified accordingly.