### PR TITLE
Log pull request number for verbose changelog

### DIFF
--- a/Sources/GitBuddyCore/Changelog/ChangelogProducer.swift
+++ b/Sources/GitBuddyCore/Changelog/ChangelogProducer.swift
@@ -86,7 +86,7 @@ final class ChangelogProducer: URLSessionInjectable {
             Log.debug("\nChangelog will use the following pull requests as input:")
             pullRequests.forEach { pullRequest in
                 guard let title = pullRequest.title, let mergedAt = pullRequest.mergedAt else { return }
-                Log.debug("- \(title), merged at: \(mergedAt)\n")
+                Log.debug("- #\(pullRequest.number): \(title), merged at: \(mergedAt)\n")
             }
         }
 


### PR DESCRIPTION
I'm currently tracking a potential bug, where a pull request wasn't included in the changelog, even though it clearly was merged after the last release tag. For that I was double-checking the list of pull requests being considered in the verbose mode. It turns out that mode didn't log pull request numbers, which wasn't very helpful.