### PR TITLE
Fix OctoKit version in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         // dev .package(path: "Submodules/WeTransfer-iOS-CI/Danger-Swift"),
         // dev .package(url: "https://github.com/WeTransfer/Mocker.git", from: "2.1.0"),
         .package(url: "https://github.com/nerdishbynature/octokit.swift", .upToNextMajor(from: "0.10.1")),
-        .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.1.0")
+        .package(url: "https://github.com/apple/swift-package-manager.git", .upToNextMinor(from: "0.4.0"))
     ],
     targets: [
         // dev .testTarget(name: "GitBuddyTests", dependencies: ["GitBuddy", "Mocker"]),

--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,7 @@ let package = Package(
         // dev .package(url: "https://github.com/danger/swift", from: "3.0.0"),
         // dev .package(path: "Submodules/WeTransfer-iOS-CI/Danger-Swift"),
         // dev .package(url: "https://github.com/WeTransfer/Mocker.git", from: "2.1.0"),
-//        .package(url: "https://github.com/nerdishbynature/octokit.swift", from: "0.9.0"),
-        .package(url: "https://github.com/nerdishbynature/octokit.swift", .branch("master")),
+        .package(url: "https://github.com/nerdishbynature/octokit.swift", .upToNextMajor(from: "0.10.1")),
         .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.1.0")
     ],
     targets: [


### PR DESCRIPTION
Versions of OctoKit before 0.10.1 can't be built with Xcode 11.4 due to nerdishbynature/octokit.swift#101. This is fixed in OctoKit 0.10.1, but Xcode didn't pull the latest version for me when reopening GitBuddy package, especially as GitBuddy doesn't have `Package.resolved` file to specify commits in its dependencies. Setting a specific version in `Package.swift` fixes that and also potentially prevents breaking changes from being introduced in OctoKit that could unexpectedly break GitBuddy.