### PR TITLE
Only include changes that are merged before the tag creation date

### DIFF
--- a/Sources/GitBuddyCore/Release/ReleaseProducer.swift
+++ b/Sources/GitBuddyCore/Release/ReleaseProducer.swift
@@ -77,7 +77,7 @@ final class ReleaseProducer: URLSessionInjectable, ShellInjectable {
     }
 
     @discardableResult public func run(isSectioned: Bool) throws -> Release {
-        let releasedTag = try tagName.map { try Tag(name: $0, created: Date()) } ?? Tag.latest()
+        let releasedTag = try tagName.map { try Tag(name: $0) } ?? Tag.latest()
         let previousTag = lastReleaseTag ?? Self.shell.execute(.previousTag)
 
         /// We're adding 60 seconds to make sure the tag commit itself is included in the changelog as well.


### PR DESCRIPTION
Whenever we were using a specific tag as input we were not using the tag's creation date. This could lead to a changelog including PRs and Issues that were merged or closed after the targeting tag creation date.

This would give wrong impressions saying something was released while it wasn't.

Fixes #33 