### PR TITLE
Fix fallback date for new tag releases

### DIFF
--- a/Sources/GitBuddyCore/Models/Tag.swift
+++ b/Sources/GitBuddyCore/Models/Tag.swift
@@ -27,7 +27,13 @@ struct Tag: ShellInjectable {
     let name: String
     let created: Date
 
-    init(name: String, created: Date? = nil) throws {
+    /// Creates a new Tag instance.
+    /// - Parameters:
+    ///   - name: The name to use for the tag.
+    ///   - created: The creation date to use. If `nil`, the date is fetched using the `git` terminal command. See `fallbackDate` for setting a date if this operation fails due to a missing tag.
+    ///   - fallbackDate: The date to use if the creation date can not be fetched from the `git` terminal command. This can be the case if we're about to create the tag during a release.
+    /// - Throws: An error if the creation date could not be found.
+    init(name: String, created: Date? = nil, fallbackDate: Date? = nil) throws {
         self.name = name
 
         if let created = created {
@@ -41,7 +47,7 @@ struct Tag: ShellInjectable {
             dateFormatter.locale = Locale(identifier: "en_US_POSIX")
             dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
 
-            guard let date = dateFormatter.date(from: tagCreationDate) else {
+            guard let date = dateFormatter.date(from: tagCreationDate) ?? fallbackDate else {
                 throw Error.missingTagCreationDate
             }
             self.created = date

--- a/Sources/GitBuddyCore/Release/ReleaseProducer.swift
+++ b/Sources/GitBuddyCore/Release/ReleaseProducer.swift
@@ -40,7 +40,7 @@ final class ReleaseProducer: URLSessionInjectable, ShellInjectable {
     }
 
     @discardableResult public func run(isSectioned: Bool) throws -> Release {
-        let releasedTag = try tagName.map { try Tag(name: $0) } ?? Tag.latest()
+        let releasedTag = try tagName.map { try Tag(name: $0, fallbackDate: Date()) } ?? Tag.latest()
         let previousTag = lastReleaseTag ?? Self.shell.execute(.previousTag)
 
         /// We're adding 60 seconds to make sure the tag commit itself is included in the changelog as well.

--- a/Tests/GitBuddyTests/Release/ReleaseProducerTests.swift
+++ b/Tests/GitBuddyTests/Release/ReleaseProducerTests.swift
@@ -206,6 +206,22 @@ final class ReleaseProducerTests: XCTestCase {
         wait(for: [mockExpectation], timeout: 0.3)
     }
 
+    /// It should use the fallback date if the tag does not yet exist.
+    func testFallbackDate() throws {
+        let mockExpectation = expectation(description: "Mocks should be called")
+        let tagName = "3.0.0"
+        var mock = Mocker.mockRelease()
+        mock.onRequest = { _, parameters in
+            guard let parameters = try? XCTUnwrap(parameters) else { return }
+            XCTAssertEqual(parameters["tag_name"] as? String, tagName)
+            mockExpectation.fulfill()
+        }
+        mock.register()
+
+        try AssertExecuteCommand(command: "gitbuddy release -s -n \(tagName)")
+        wait(for: [mockExpectation], timeout: 0.3)
+    }
+
     /// It should not contain changes that are merged into the target branch after the creation date of the tag we're using.
     func testIncludedChangesForUsedTagName() throws {
         let existingChangelog = """


### PR DESCRIPTION
When we're creating a new tag, the date can't be fetched from the `git` terminal command. For these cases, we need to have a fallback date.