### PR TITLE
Always capitalize first word on changelog item

### DIFF
--- a/Sources/GitBuddyCore/Models/ChangelogItem.swift
+++ b/Sources/GitBuddyCore/Models/ChangelogItem.swift
@@ -33,6 +33,7 @@ struct ChangelogItem {
 
     var title: String? {
         guard var title = input.title else { return nil }
+        title = title.prefix(1).uppercased() + title.dropFirst()
         if let htmlURL = input.htmlURL {
             title += " ([#\(input.number)](\(htmlURL)))"
         }

--- a/Tests/GitBuddyTests/Models/ChangelogItemTests.swift
+++ b/Tests/GitBuddyTests/Models/ChangelogItemTests.swift
@@ -18,6 +18,18 @@ final class ChangelogItemTests: XCTestCase {
         XCTAssertNil(item.title)
     }
 
+    /// It should return `title` as is.
+    func testFirstUpperCaseTitle() {
+        let item = ChangelogItem(input: MockChangelogInput(title: "Update README.md"), closedBy: MockedPullRequest())
+        XCTAssertEqual(item.title, "Update README.md")
+    }
+
+    /// It should capitalize first word in `title`
+    func testFirstLowerCaseTitle() {
+        let item = ChangelogItem(input: MockChangelogInput(title: "ignoring query example"), closedBy: MockedPullRequest())
+        XCTAssertEqual(item.title, "Ignoring query example")
+    }
+
     /// It should correctly display the number and URL.
     func testNumberURL() {
         let input = MockChangelogInput(number: 1, title: UUID().uuidString, htmlURL: URL(string: "https://www.fakeurl.com")!)


### PR DESCRIPTION
Fix #56 

Change format of changelog item to always capitalize first word (if applicable)