### PR TITLE
Avoid referring to the `master` branch in ShellCommand.rawValue

### DIFF
--- a/Sources/GitBuddyCore/Helpers/Shell.swift
+++ b/Sources/GitBuddyCore/Helpers/Shell.swift
@@ -18,7 +18,7 @@ enum ShellCommand {
     var rawValue: String {
         switch self {
         case .fetchTags:
-            return "git fetch --tags origin master --no-recurse-submodules -q"
+            return "git fetch --tags origin --no-recurse-submodules -q"
         case .latestTag:
             return "git describe --abbrev=0 --tags `git rev-list --tags --max-count=1 --no-walk`"
         case .previousTag:


### PR DESCRIPTION
This refers to `master` even when the specified base branch option is not `master`.