### PR TITLE
Fix compilation error that happened due to naming changes in OctoKit.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@ playground.xcworkspace
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 Packages/
 Package.pins
-Package.resolved
 *.xcodeproj
 #
 # Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,34 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "OctoKit",
+        "repositoryURL": "https://github.com/nerdishbynature/octokit.swift",
+        "state": {
+          "branch": null,
+          "revision": "9521cdff919053868ab13cd08a228f7bc1bde2a9",
+          "version": "0.11.0"
+        }
+      },
+      {
+        "package": "RequestKit",
+        "repositoryURL": "https://github.com/nerdishbynature/RequestKit.git",
+        "state": {
+          "branch": null,
+          "revision": "fd5e9e99aada7432170366c9e95967011ce13bad",
+          "version": "2.4.0"
+        }
+      },
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
+        "state": {
+          "branch": null,
+          "revision": "9564d61b08a5335ae0a36f789a7d71493eacadfc",
+          "version": "0.3.2"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Sources/GitBuddyCore/GitHub/IssuesFetcher.swift
+++ b/Sources/GitBuddyCore/GitHub/IssuesFetcher.swift
@@ -20,7 +20,7 @@ struct IssuesFetcher {
 
         var result: Result<[Issue], Swift.Error>!
 
-        octoKit.issues(session, owner: project.organisation, repository: project.repository, state: .Closed) { (response) in
+        octoKit.issues(session, owner: project.organisation, repository: project.repository, state: .closed) { (response) in
             switch response {
             case .success(let issues):
                 result = .success(issues)

--- a/Sources/GitBuddyCore/GitHub/PullRequestFetcher.swift
+++ b/Sources/GitBuddyCore/GitHub/PullRequestFetcher.swift
@@ -23,7 +23,7 @@ struct PullRequestFetcher {
 
         var result: Result<[PullRequest], Swift.Error>!
 
-        octoKit.pullRequests(session, owner: project.organisation, repository: project.repository, base: baseBranch, state: .Closed, sort: .updated, direction: .desc) { (response) in
+        octoKit.pullRequests(session, owner: project.organisation, repository: project.repository, base: baseBranch, state: .closed, sort: .updated, direction: .desc) { (response) in
             switch response {
             case .success(let pullRequests):
                 result = .success(pullRequests)


### PR DESCRIPTION
Octokit was updated and therefore the project did not compile anymore. Because of this our CI pipeline failed.
Like we discussed I also checked in the `package.resolved` file so that we won't run int a similar issue again.