### PR TITLE
Add a new `--json` parameter 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ Package.pins
 .swiftpm
 
 .build/
+.spm-build/
 
 # CocoaPods
 #

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -1,4 +1,0 @@
-import Danger
-import WeTransferPRLinter
-
-WeTransferPRLinter.lint()

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "Mocker",
+        "repositoryURL": "https://github.com/WeTransfer/Mocker.git",
+        "state": {
+          "branch": null,
+          "revision": "077c52a31f5ebb649ebe546cc77d8647760b2279",
+          "version": "2.5.5"
+        }
+      },
+      {
         "package": "OctoKit",
         "repositoryURL": "https://github.com/nerdishbynature/octokit.swift",
         "state": {
@@ -24,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "9564d61b08a5335ae0a36f789a7d71493eacadfc",
-          "version": "0.3.2"
+          "revision": "e1465042f195f374b94f915ba8ca49de24300a0d",
+          "version": "1.0.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,5 @@
 // swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
-// We're hiding dev, test, and danger dependencies with // dev to make sure they're not fetched by users of this package.
 import PackageDescription
 
 let package = Package(
@@ -9,19 +8,15 @@ let package = Package(
         .macOS(.v10_15)
         ],
     products: [
-        // dev .library(name: "DangerDeps", type: .dynamic, targets: ["DangerDependencies"]),
         .executable(name: "GitBuddy", targets: ["GitBuddy"])
     ],
     dependencies: [
-        // dev .package(url: "https://github.com/danger/swift", from: "3.0.0"),
-        // dev .package(path: "Submodules/WeTransfer-iOS-CI/Danger-Swift"),
         .package(url: "https://github.com/WeTransfer/Mocker.git", .upToNextMajor(from: "2.1.0")),
         .package(url: "https://github.com/nerdishbynature/octokit.swift", .upToNextMajor(from: "0.10.1")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.0.0"))
     ],
     targets: [
-        // dev .target(name: "DangerDependencies", dependencies: ["Danger", "WeTransferPRLinter"], path: "Submodules/WeTransfer-iOS-CI/Danger-Swift", sources: ["DangerFakeSource.swift"]),
-        .target(name: "GitBuddy", dependencies: ["GitBuddyCore"]),
+        .executableTarget(name: "GitBuddy", dependencies: ["GitBuddyCore"]),
         .target(name: "GitBuddyCore", dependencies: [
             .product(name: "OctoKit", package: "octokit.swift"),
             .product(name: "ArgumentParser", package: "swift-argument-parser")

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 // We're hiding dev, test, and danger dependencies with // dev to make sure they're not fetched by users of this package.
 import PackageDescription
@@ -15,14 +15,17 @@ let package = Package(
     dependencies: [
         // dev .package(url: "https://github.com/danger/swift", from: "3.0.0"),
         // dev .package(path: "Submodules/WeTransfer-iOS-CI/Danger-Swift"),
-        // dev .package(url: "https://github.com/WeTransfer/Mocker.git", from: "2.1.0"),
+        .package(url: "https://github.com/WeTransfer/Mocker.git", .upToNextMajor(from: "2.1.0")),
         .package(url: "https://github.com/nerdishbynature/octokit.swift", .upToNextMajor(from: "0.10.1")),
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "0.0.1")
+        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.0.0"))
     ],
     targets: [
-        // dev .testTarget(name: "GitBuddyTests", dependencies: ["GitBuddy", "Mocker"]),
         // dev .target(name: "DangerDependencies", dependencies: ["Danger", "WeTransferPRLinter"], path: "Submodules/WeTransfer-iOS-CI/Danger-Swift", sources: ["DangerFakeSource.swift"]),
         .target(name: "GitBuddy", dependencies: ["GitBuddyCore"]),
-        .target(name: "GitBuddyCore", dependencies: ["OctoKit", "ArgumentParser"])
+        .target(name: "GitBuddyCore", dependencies: [
+            .product(name: "OctoKit", package: "octokit.swift"),
+            .product(name: "ArgumentParser", package: "swift-argument-parser")
+        ]),
+        .testTarget(name: "GitBuddyTests", dependencies: ["GitBuddy", "Mocker"])
     ]
 )

--- a/Sources/GitBuddyCore/Commands/ReleaseCommand.swift
+++ b/Sources/GitBuddyCore/Commands/ReleaseCommand.swift
@@ -39,6 +39,9 @@ struct ReleaseCommand: ParsableCommand {
     @Flag(name: .customLong("sections"), help: "Whether the changelog should be split into sections. Defaults to false.")
     private var isSectioned: Bool = false
 
+    @Flag(name: .customLong("json"), help: "Whether the release output should be in JSON, containing more details. Defaults to false.")
+    private var shouldUseJSONOutput: Bool = false
+
     @Flag(name: .long, help: "Show extra logging for debugging purposes")
     private var verbose: Bool = false
 
@@ -54,6 +57,13 @@ struct ReleaseCommand: ParsableCommand {
                                                   lastReleaseTag: lastReleaseTag,
                                                   baseBranch: baseBranch)
         let release = try releaseProducer.run(isSectioned: isSectioned)
-        Log.message(release.url.absoluteString)
+
+        if shouldUseJSONOutput {
+            let jsonData = try JSONEncoder().encode(release)
+            let jsonString = String(decoding: jsonData, as: UTF8.self)
+            Log.message(jsonString)
+        } else {
+            Log.message(release.url.absoluteString)
+        }
     }
 }

--- a/Sources/GitBuddyCore/Models/Release.swift
+++ b/Sources/GitBuddyCore/Models/Release.swift
@@ -9,8 +9,9 @@
 import Foundation
 
 /// A release that exists on GitHub.
-struct Release {
+struct Release: Encodable {
     let tag: Tag
     let url: URL
     let title: String
+    let changelog: String
 }

--- a/Sources/GitBuddyCore/Models/Tag.swift
+++ b/Sources/GitBuddyCore/Models/Tag.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct Tag: ShellInjectable {
+struct Tag: ShellInjectable, Encodable {
     enum Error: Swift.Error, CustomStringConvertible {
         case missingTagCreationDate
         case noTagsAvailable

--- a/Sources/GitBuddyCore/Release/ReleaseProducer.swift
+++ b/Sources/GitBuddyCore/Release/ReleaseProducer.swift
@@ -21,10 +21,10 @@ final class ReleaseProducer: URLSessionInjectable, ShellInjectable {
     let releaseTitle: String?
     let lastReleaseTag: String?
     let baseBranch: String
-    
+
     init(changelogPath: String?, skipComments: Bool, isPrerelease: Bool, targetCommitish: String? = nil, tagName: String? = nil, releaseTitle: String? = nil, lastReleaseTag: String? = nil, baseBranch: String? = nil) throws {
         try Octokit.authenticate()
-        
+
         if let changelogPath = changelogPath {
             changelogURL = URL(string: changelogPath)
         } else {

--- a/Sources/GitBuddyCore/Release/ReleaseProducer.swift
+++ b/Sources/GitBuddyCore/Release/ReleaseProducer.swift
@@ -136,6 +136,6 @@ final class ReleaseProducer: URLSessionInjectable, ShellInjectable {
         }
         group.wait()
         let releaseURL = try result.get()
-        return Release(tag: tag, url: releaseURL, title: tag.name)
+        return Release(tag: tag, url: releaseURL, title: tag.name, changelog: body)
     }
 }

--- a/Tests/GitBuddyTests/Changelog/ChangelogCommandTests.swift
+++ b/Tests/GitBuddyTests/Changelog/ChangelogCommandTests.swift
@@ -32,7 +32,7 @@ final class ChangelogCommandTests: XCTestCase {
         Mocker.mockPullRequests()
         Mocker.mockForIssueNumber(39)
         MockedShell.mockGITProject(organisation: "WeTransfer", repository: "Diagnostics")
-        
+
         let token = "username:79B02BE4-38D1-4E3D-9B41-4E0739761512"
         mockGITAuthentication(token)
         try executeCommand("gitbuddy changelog")
@@ -44,7 +44,7 @@ final class ChangelogCommandTests: XCTestCase {
         Mocker.mockPullRequests()
         Mocker.mockForIssueNumber(39)
         MockedShell.mockGITProject(organisation: "WeTransfer", repository: "Diagnostics")
-        
+
         let expectedChangelog = """
         - Add charset utf-8 to html head \
         ([#50](https://github.com/WeTransfer/Diagnostics/pull/50)) via [@AvdLee](https://github.com/AvdLee)

--- a/Tests/GitBuddyTests/Changelog/ChangelogCommandTests.swift
+++ b/Tests/GitBuddyTests/Changelog/ChangelogCommandTests.swift
@@ -35,7 +35,7 @@ final class ChangelogCommandTests: XCTestCase {
         
         let token = "username:79B02BE4-38D1-4E3D-9B41-4E0739761512"
         mockGITAuthentication(token)
-        try AssertExecuteCommand(command: "gitbuddy changelog")
+        try executeCommand("gitbuddy changelog")
         XCTAssertEqual(URLSessionInjector.urlSession.configuration.httpAdditionalHeaders?["Authorization"] as? String, "Basic dXNlcm5hbWU6NzlCMDJCRTQtMzhEMS00RTNELTlCNDEtNEUwNzM5NzYxNTEy")
     }
 
@@ -52,7 +52,7 @@ final class ChangelogCommandTests: XCTestCase {
         ([#39](https://github.com/WeTransfer/Diagnostics/issues/39)) via [@AvdLee](https://github.com/AvdLee)
         """
 
-        try AssertExecuteCommand(command: "gitbuddy changelog", expected: expectedChangelog)
+        try AssertExecuteCommand("gitbuddy changelog", expected: expectedChangelog)
     }
 
     /// It should correctly output the changelog.
@@ -81,7 +81,7 @@ final class ChangelogCommandTests: XCTestCase {
         - Add charset utf-8 to html head ([#50](https://github.com/WeTransfer/Diagnostics/pull/50)) via [@AvdLee](https://github.com/AvdLee)
         """
 
-        try AssertExecuteCommand(command: "gitbuddy changelog --sections", expected: expectedChangelog)
+        try AssertExecuteCommand("gitbuddy changelog --sections", expected: expectedChangelog)
     }
 
     /// It should default to master branch.

--- a/Tests/GitBuddyTests/GitBuddyCommandTests.swift
+++ b/Tests/GitBuddyTests/GitBuddyCommandTests.swift
@@ -14,7 +14,7 @@ final class GitBuddyCommandTests: XCTestCase {
     /// It should throw an error if the GitHub access token was not set.
     func testMissingAccessToken() {
         do {
-            try AssertExecuteCommand(command: "gitbuddy changelog")
+            try executeCommand("gitbuddy changelog")
         } catch {
             XCTAssertEqual(error as? Token.Error, .missingAccessToken)
         }
@@ -24,7 +24,7 @@ final class GitBuddyCommandTests: XCTestCase {
     func testInvalidAccessToken() {
         do {
             mockGITAuthentication(UUID().uuidString)
-            try AssertExecuteCommand(command: "gitbuddy changelog")
+            try executeCommand("gitbuddy changelog")
         } catch {
             XCTAssertEqual(error as? Token.Error, .invalidAccessToken)
         }

--- a/Tests/GitBuddyTests/GitHub/CommenterTests.swift
+++ b/Tests/GitBuddyTests/GitHub/CommenterTests.swift
@@ -28,7 +28,7 @@ final class CommenterTests: XCTestCase {
     func testWatermark() throws {
         Mocker.mockPullRequests()
         let latestTag = try Tag.latest()
-        let release = Release(tag: latestTag, url: URL(string: "https://www.fakegithub.com")!, title: "Release title")
+        let release = Release(tag: latestTag, url: URL(string: "https://www.fakegithub.com")!, title: "Release title", changelog: "")
         let project = GITProject(organisation: "WeTransfer", repository: "GitBuddy")
 
         let mockExpectation = expectation(description: "Mock should be called")

--- a/Tests/GitBuddyTests/Release/ReleaseProducerTests.swift
+++ b/Tests/GitBuddyTests/Release/ReleaseProducerTests.swift
@@ -37,13 +37,18 @@ final class ReleaseProducerTests: XCTestCase {
     func testAccessTokenConfiguration() throws {
         let token = "username:79B02BE4-38D1-4E3D-9B41-4E0739761512"
         mockGITAuthentication(token)
-        try AssertExecuteCommand(command: "gitbuddy release -s")
+        try executeCommand("gitbuddy release -s")
         XCTAssertEqual(URLSessionInjector.urlSession.configuration.httpAdditionalHeaders?["Authorization"] as? String, "Basic dXNlcm5hbWU6NzlCMDJCRTQtMzhEMS00RTNELTlCNDEtNEUwNzM5NzYxNTEy")
     }
 
     /// It should correctly output the release URL.
-    func testReleaseOutput() throws {
-        try AssertExecuteCommand(command: "gitbuddy release -s", expected: "https://github.com/WeTransfer/ChangelogProducer/releases/tag/1.0.1")
+    func testReleaseOutputURL() throws {
+        try AssertExecuteCommand("gitbuddy release -s", expected: "https://github.com/WeTransfer/ChangelogProducer/releases/tag/1.0.1")
+    }
+
+    func testReleaseOutputJSON() throws {
+        let output = try executeCommand("gitbuddy release -s --json")
+        XCTAssertTrue(output.contains("{\"title\":\"1.0.1\",\"url\":\"https:\\/\\/github.com\\/WeTransfer\\/ChangelogProducer\\/releases\\/tag\\/1.0.1\",\"tag\":{\"name\":\"1.0.1\",\"created\""))
     }
 
     /// It should set the parameters correctly.
@@ -66,7 +71,7 @@ final class ReleaseProducerTests: XCTestCase {
         }
         mock.register()
 
-        try AssertExecuteCommand(command: "gitbuddy release -s")
+        try executeCommand("gitbuddy release -s")
         wait(for: [mockExpectation], timeout: 0.3)
     }
 
@@ -78,7 +83,7 @@ final class ReleaseProducerTests: XCTestCase {
         """
         let tempFileURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true).appendingPathComponent("Changelog.md")
         XCTAssertTrue(FileManager.default.createFile(atPath: tempFileURL.path, contents: Data(existingChangelog.utf8), attributes: nil))
-        try AssertExecuteCommand(command: "gitbuddy release -s -c \(tempFileURL.path)")
+        try executeCommand("gitbuddy release -s -c \(tempFileURL.path)")
         let updatedChangelogContents = try String(contentsOfFile: tempFileURL.path)
 
         XCTAssertEqual(updatedChangelogContents, """
@@ -99,7 +104,7 @@ final class ReleaseProducerTests: XCTestCase {
         """
         let tempFileURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true).appendingPathComponent("Changelog.md")
         XCTAssertTrue(FileManager.default.createFile(atPath: tempFileURL.path, contents: Data(existingChangelog.utf8), attributes: nil))
-        try AssertExecuteCommand(command: "gitbuddy release --sections -s -c \(tempFileURL.path)")
+        try executeCommand("gitbuddy release --sections -s -c \(tempFileURL.path)")
 
         let updatedChangelogContents = try String(contentsOfFile: tempFileURL.path)
 
@@ -142,7 +147,7 @@ final class ReleaseProducerTests: XCTestCase {
             }
             mock.register()
         }
-        try AssertExecuteCommand(command: "gitbuddy release")
+        try executeCommand("gitbuddy release")
         wait(for: [mocksExpectations], timeout: 2.0)
     }
 
@@ -156,7 +161,7 @@ final class ReleaseProducerTests: XCTestCase {
         }
         mock.register()
 
-        try AssertExecuteCommand(command: "gitbuddy release -s")
+        try executeCommand("gitbuddy release -s")
         wait(for: [mockExpectation], timeout: 0.3)
     }
 
@@ -171,7 +176,7 @@ final class ReleaseProducerTests: XCTestCase {
         }
         mock.register()
 
-        try AssertExecuteCommand(command: "gitbuddy release -s -p")
+        try executeCommand("gitbuddy release -s -p")
         wait(for: [mockExpectation], timeout: 0.3)
     }
 
@@ -186,7 +191,7 @@ final class ReleaseProducerTests: XCTestCase {
         }
         mock.register()
 
-        try AssertExecuteCommand(command: "gitbuddy release -s -t develop")
+        try executeCommand("gitbuddy release -s -t develop")
         wait(for: [mockExpectation], timeout: 0.3)
     }
 
@@ -202,7 +207,7 @@ final class ReleaseProducerTests: XCTestCase {
         }
         mock.register()
 
-        try AssertExecuteCommand(command: "gitbuddy release -s -n \(tagName)")
+        try executeCommand("gitbuddy release -s -n \(tagName)")
         wait(for: [mockExpectation], timeout: 0.3)
     }
 
@@ -218,7 +223,7 @@ final class ReleaseProducerTests: XCTestCase {
         }
         mock.register()
 
-        try AssertExecuteCommand(command: "gitbuddy release -s -n \(tagName)")
+        try executeCommand("gitbuddy release -s -n \(tagName)")
         wait(for: [mockExpectation], timeout: 0.3)
     }
 
@@ -238,7 +243,7 @@ final class ReleaseProducerTests: XCTestCase {
         let tempFileURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true).appendingPathComponent("Changelog.md")
         XCTAssertTrue(FileManager.default.createFile(atPath: tempFileURL.path, contents: Data(existingChangelog.utf8), attributes: nil))
 
-        try AssertExecuteCommand(command: "gitbuddy release -s -n \(tagName) -c \(tempFileURL.path)")
+        try executeCommand("gitbuddy release -s -n \(tagName) -c \(tempFileURL.path)")
 
         let updatedChangelogContents = try String(contentsOfFile: tempFileURL.path)
 
@@ -267,7 +272,7 @@ final class ReleaseProducerTests: XCTestCase {
         }
         mock.register()
 
-        try AssertExecuteCommand(command: "gitbuddy release -s -r \(title)")
+        try executeCommand("gitbuddy release -s -r \(title)")
         wait(for: [mockExpectation], timeout: 0.3)
     }
 
@@ -282,6 +287,6 @@ final class ReleaseProducerTests: XCTestCase {
         let baseBranch = UUID().uuidString
         Mocker.mockPullRequests(baseBranch: baseBranch)
 
-        try AssertExecuteCommand(command: "gitbuddy release -s -l \(lastReleaseTag) -b \(baseBranch)")
+        try executeCommand("gitbuddy release -s -l \(lastReleaseTag) -b \(baseBranch)")
     }
 }

--- a/Tests/GitBuddyTests/TestHelpers/XCTestExtensions.swift
+++ b/Tests/GitBuddyTests/TestHelpers/XCTestExtensions.swift
@@ -26,7 +26,13 @@ extension XCTest {
     ///   - command: The command to execute. This command can be exactly the same as you would use in the terminal. E.g. "gitbuddy changelog".
     ///   - expected: The expected outcome printed in the console.
     /// - Throws: The error occured while executing the command.
-    func AssertExecuteCommand(command: String, expected: String? = nil, file: StaticString = #file, line: UInt = #line) throws {
+    func AssertExecuteCommand(_ command: String, expected: String, file: StaticString = #file, line: UInt = #line) throws {
+        let output = try executeCommand(command)
+        AssertEqualStringsIgnoringTrailingWhitespace(expected, output, file: file, line: line)
+    }
+
+    @discardableResult
+    func executeCommand(_ command: String) throws -> String {
         let splitCommand = command.split(separator: " ")
         let arguments = splitCommand.dropFirst().map(String.init)
 
@@ -39,9 +45,7 @@ extension XCTest {
 
         try gitBuddyCommand.run()
 
-        if let expected = expected {
-            AssertEqualStringsIgnoringTrailingWhitespace(expected, output, file: file, line: line)
-        }
+        return output
     }
 }
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,12 +5,12 @@ import "./../Submodules/WeTransfer-iOS-CI/Fastlane/Fastfile"
 
 desc "Run the tests and prepare for Danger"
 lane :test do |options|
-	spm(command: "generate-xcodeproj")
-	test_project(
-		project_name: "GitBuddy", 
-		scheme: "GitBuddy-Package",
-		device: nil,
-		destination: "platform=macOS")
+	test_package(
+		package_name: 'GitBuddy',
+        package_path: ENV['PWD'],
+        device: nil,
+		destination: "platform=macOS"
+	)
 end
 
 desc "Updates the local version before creating the regular release"


### PR DESCRIPTION
- [x] Updated `Package.swift` file
- [x] Updated `ArgumentParser` dependency
- [x] Added a new `--json` parameter to allow outputting the release metadata in JSON. This allows to not only read out the release URL, but also the committed changelog. This could enable implementors to only create a changelog once and prevent running into API rate limits.