### PR TITLE
Add a new flag to use as target date

### DIFF
--- a/Sources/GitBuddyCore/Commands/ReleaseCommand.swift
+++ b/Sources/GitBuddyCore/Commands/ReleaseCommand.swift
@@ -21,10 +21,10 @@ struct ReleaseCommand: ParsableCommand {
     @Flag(name: [.customLong("use-pre-release"), .customShort("p")], help: "Create the release as a pre-release.")
     var isPrerelease: Bool = false
 
-    @Option(name: .shortAndLong, help: "Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists. Default: the repository's default branch (usually master).")
+    @Option(name: .shortAndLong, help: "Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists. Default: the repository's default branch (usually main).")
     var targetCommitish: String?
 
-    @Option(name: [.long, .customShort("n")], help: "The name of the tag. Default: takes the last created tag to publish as a GitHub release.")
+    @Option(name: [.long, .customShort("n")], help: "The name of the tag. If set, `changelogToTag` is required too. Default: takes the last created tag to publish as a GitHub release.")
     var tagName: String?
 
     @Option(name: .shortAndLong, help: "The title of the release. Default: uses the tag name.")
@@ -32,6 +32,9 @@ struct ReleaseCommand: ParsableCommand {
 
     @Option(name: .shortAndLong, help: "The last release tag to use as a base for the changelog creation. Default: previous tag.")
     var lastReleaseTag: String?
+
+    @Option(name: .customLong("changelogToTag"), help: "If set, the date of this tag will be used as the limit for the changelog creation. This variable should be passed when `tagName` is set. Default: latest tag.")
+    var changelogToTag: String?
 
     @Option(name: .shortAndLong, help: "The base branch to compare with for generating the changelog. Defaults to master.")
     var baseBranch: String?
@@ -55,7 +58,8 @@ struct ReleaseCommand: ParsableCommand {
                                                   tagName: tagName,
                                                   releaseTitle: releaseTitle,
                                                   lastReleaseTag: lastReleaseTag,
-                                                  baseBranch: baseBranch)
+                                                  baseBranch: baseBranch,
+                                                  changelogToTag: changelogToTag)
         let release = try releaseProducer.run(isSectioned: isSectioned)
 
         if shouldUseJSONOutput {

--- a/Sources/GitBuddyCore/Models/Release.swift
+++ b/Sources/GitBuddyCore/Models/Release.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// A release that exists on GitHub.
 struct Release: Encodable {
-    let tag: Tag
+    let tagName: String
     let url: URL
     let title: String
     let changelog: String

--- a/Sources/GitBuddyCore/Models/Tag.swift
+++ b/Sources/GitBuddyCore/Models/Tag.swift
@@ -31,15 +31,19 @@ struct Tag: ShellInjectable, Encodable {
     /// - Parameters:
     ///   - name: The name to use for the tag.
     ///   - created: The creation date to use. If `nil`, the date is fetched using the `git` terminal command. See `fallbackDate` for setting a date if this operation fails due to a missing tag.
-    ///   - fallbackDate: The date to use if the creation date can not be fetched from the `git` terminal command. This can be the case if we're about to create the tag during a release.
     /// - Throws: An error if the creation date could not be found.
-    init(name: String, created: Date? = nil, fallbackDate: Date? = nil) throws {
+    init(name: String, created: Date? = nil) throws {
         self.name = name
 
         if let created = created {
             self.created = created
         } else {
             let tagCreationDate = Self.shell.execute(.tagCreationDate(tag: name))
+            if tagCreationDate.isEmpty {
+                Log.debug("Tag creation date could not be found")
+                throw Error.missingTagCreationDate
+            }
+
             Log.debug("Tag \(name) is created at \(tagCreationDate)")
 
             let dateFormatter = DateFormatter()
@@ -47,7 +51,7 @@ struct Tag: ShellInjectable, Encodable {
             dateFormatter.locale = Locale(identifier: "en_US_POSIX")
             dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
 
-            guard let date = dateFormatter.date(from: tagCreationDate) ?? fallbackDate else {
+            guard let date = dateFormatter.date(from: tagCreationDate) else {
                 throw Error.missingTagCreationDate
             }
             self.created = date

--- a/Sources/GitBuddyCore/Release/ReleaseProducer.swift
+++ b/Sources/GitBuddyCore/Release/ReleaseProducer.swift
@@ -12,6 +12,17 @@ import OctoKit
 /// Capable of producing a release, adjusting a Changelog file, and posting comments to released issues/PRs.
 final class ReleaseProducer: URLSessionInjectable, ShellInjectable {
 
+    enum Error: Swift.Error, CustomStringConvertible {
+        case changelogTargetDateMissing
+
+        var description: String {
+            switch self {
+            case .changelogTargetDateMissing:
+                return "Tag name is set, but `changelogToTag` is missing"
+            }
+        }
+    }
+
     private lazy var octoKit: Octokit = Octokit()
     let changelogURL: Foundation.URL?
     let skipComments: Bool
@@ -20,9 +31,10 @@ final class ReleaseProducer: URLSessionInjectable, ShellInjectable {
     let tagName: String?
     let releaseTitle: String?
     let lastReleaseTag: String?
+    let changelogToTag: String?
     let baseBranch: String
-    
-    init(changelogPath: String?, skipComments: Bool, isPrerelease: Bool, targetCommitish: String? = nil, tagName: String? = nil, releaseTitle: String? = nil, lastReleaseTag: String? = nil, baseBranch: String? = nil) throws {
+
+    init(changelogPath: String?, skipComments: Bool, isPrerelease: Bool, targetCommitish: String? = nil, tagName: String? = nil, releaseTitle: String? = nil, lastReleaseTag: String? = nil, baseBranch: String? = nil, changelogToTag: String? = nil) throws {
         try Octokit.authenticate()
         
         if let changelogPath = changelogPath {
@@ -36,25 +48,33 @@ final class ReleaseProducer: URLSessionInjectable, ShellInjectable {
         self.tagName = tagName
         self.releaseTitle = releaseTitle
         self.lastReleaseTag = lastReleaseTag
+        self.changelogToTag = changelogToTag
         self.baseBranch = baseBranch ?? "master"
     }
 
     @discardableResult public func run(isSectioned: Bool) throws -> Release {
-        let releasedTag = try tagName.map { try Tag(name: $0, fallbackDate: Date()) } ?? Tag.latest()
-        let previousTag = lastReleaseTag ?? Self.shell.execute(.previousTag)
+        /// If a tagname exists, it means we're creating a new tag.
+        /// In this case, we need another way to fetch the from date for the changelog.
+        if tagName != nil, changelogToTag == nil {
+            throw Error.changelogTargetDateMissing
+        }
+
+        let changelogToTag = try changelogToTag.map { try Tag(name: $0) } ?? Tag.latest()
+        let changelogSinceTag = lastReleaseTag ?? Self.shell.execute(.previousTag)
 
         /// We're adding 60 seconds to make sure the tag commit itself is included in the changelog as well.
-        let toDate = releasedTag.created.addingTimeInterval(60)
-        let changelogProducer = try ChangelogProducer(since: .tag(tag: previousTag), to: toDate, baseBranch: baseBranch)
+        let toDate = changelogToTag.created.addingTimeInterval(60)
+        let changelogProducer = try ChangelogProducer(since: .tag(tag: changelogSinceTag), to: toDate, baseBranch: baseBranch)
         let changelog = try changelogProducer.run(isSectioned: isSectioned)
         Log.debug("\(changelog)\n")
 
-        try updateChangelogFile(adding: changelog.description, for: releasedTag)
+        let tagName = tagName ?? changelogToTag.name
+        try updateChangelogFile(adding: changelog.description, for: tagName)
 
         let repositoryName = Self.shell.execute(.repositoryName)
         let project = GITProject.current()
-        Log.debug("Creating a release for tag \(releasedTag.name) at repository \(repositoryName)")
-        let release = try createRelease(using: project, tag: releasedTag, targetCommitish: targetCommitish, title: releaseTitle, body: changelog.description)
+        Log.debug("Creating a release for tag \(tagName) at repository \(repositoryName)")
+        let release = try createRelease(using: project, tagName: tagName, targetCommitish: targetCommitish, title: releaseTitle, body: changelog.description)
         postComments(for: changelog, project: project, release: release)
 
         Log.debug("Result of creating the release:\n")
@@ -68,7 +88,7 @@ final class ReleaseProducer: URLSessionInjectable, ShellInjectable {
         }
         let dispatchGroup = DispatchGroup()
         for (pullRequestID, issueIDs) in changelog.itemIdentifiers {
-            Log.debug("Marking PR #\(pullRequestID) as having been released in version #\(release.tag.name)")
+            Log.debug("Marking PR #\(pullRequestID) as having been released in version #\(release.tagName)")
             dispatchGroup.enter()
             Commenter.post(.releasedPR(release: release), on: pullRequestID, at: project) {
                 dispatchGroup.leave()
@@ -88,8 +108,8 @@ final class ReleaseProducer: URLSessionInjectable, ShellInjectable {
     /// Appends the changelog to the changelog file if the argument is set.
     /// - Parameters:
     ///   - changelog: The changelog to append to the changelog file.
-    ///   - tag: The tag that is used as the title for the newly added section.
-    private func updateChangelogFile(adding changelog: String, for tag: Tag) throws {
+    ///   - tagName: The name of the tag that is used as the title for the newly added section.
+    private func updateChangelogFile(adding changelog: String, for tagName: String) throws {
         guard let changelogURL = changelogURL else {
             Log.debug("Skipping changelog file updating")
             return
@@ -97,7 +117,7 @@ final class ReleaseProducer: URLSessionInjectable, ShellInjectable {
 
         let currentContent = try String(contentsOfFile: changelogURL.path)
         let newContent = """
-        ### \(tag.name)
+        ### \(tagName)
         \(changelog)\n
         \(currentContent)
         """
@@ -107,25 +127,26 @@ final class ReleaseProducer: URLSessionInjectable, ShellInjectable {
         handle.closeFile()
     }
 
-    private func createRelease(using project: GITProject, tag: Tag, targetCommitish: String?, title: String?, body: String) throws -> Release {
+    private func createRelease(using project: GITProject, tagName: String, targetCommitish: String?, title: String?, body: String) throws -> Release {
         let group = DispatchGroup()
         group.enter()
 
+        let releaseTitle = title ?? tagName
         Log.debug("""
         \nCreating a new release:
             owner:           \(project.organisation)
             repo:            \(project.repository)
-            tagName:         \(tag.name)
+            tagName:         \(tagName)
             targetCommitish: \(targetCommitish ?? "default")
             prerelease:      \(isPrerelease)
             draft:           false
-            title:           \(title ?? tag.name)
+            title:           \(releaseTitle)
             body:
             \(body)\n
         """)
 
         var result: Result<Foundation.URL, Swift.Error>!
-        octoKit.postRelease(urlSession, owner: project.organisation, repository: project.repository, tagName: tag.name, targetCommitish: targetCommitish, name: title ?? tag.name, body: body, prerelease: isPrerelease, draft: false) { (response) in
+        octoKit.postRelease(urlSession, owner: project.organisation, repository: project.repository, tagName: tagName, targetCommitish: targetCommitish, name: releaseTitle, body: body, prerelease: isPrerelease, draft: false) { (response) in
             switch response {
             case .success(let release):
                 result = .success(release.htmlURL)
@@ -136,6 +157,6 @@ final class ReleaseProducer: URLSessionInjectable, ShellInjectable {
         }
         group.wait()
         let releaseURL = try result.get()
-        return Release(tag: tag, url: releaseURL, title: tag.name, changelog: body)
+        return Release(tagName: tagName, url: releaseURL, title: releaseTitle, changelog: body)
     }
 }

--- a/Tests/GitBuddyTests/GitHub/CommenterTests.swift
+++ b/Tests/GitBuddyTests/GitHub/CommenterTests.swift
@@ -28,7 +28,7 @@ final class CommenterTests: XCTestCase {
     func testWatermark() throws {
         Mocker.mockPullRequests()
         let latestTag = try Tag.latest()
-        let release = Release(tag: latestTag, url: URL(string: "https://www.fakegithub.com")!, title: "Release title", changelog: "")
+        let release = Release(tagName: latestTag.name, url: URL(string: "https://www.fakegithub.com")!, title: "Release title", changelog: "")
         let project = GITProject(organisation: "WeTransfer", repository: "GitBuddy")
 
         let mockExpectation = expectation(description: "Mock should be called")


### PR DESCRIPTION
Our previous implementation contained a bug in which the date of triggering the release would be used as a limit range for the changelog creation. This would cause incorrect changelog updates and issue messages sending out that something was released while it actually was not.

By introducing a new `changelogToTag` parameter, we're solving this.