### PR TITLE
Make use of the target commitish date

### DIFF
--- a/Sources/GitBuddyCore/Helpers/DateFormatters.swift
+++ b/Sources/GitBuddyCore/Helpers/DateFormatters.swift
@@ -1,0 +1,18 @@
+//
+//  DateFormatters.swift
+//  
+//
+//  Created by Antoine van der Lee on 25/01/2022.
+//
+
+import Foundation
+
+enum Formatter {
+    static let gitDateFormatter: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return dateFormatter
+    }()
+}

--- a/Sources/GitBuddyCore/Helpers/DateFormatters.swift
+++ b/Sources/GitBuddyCore/Helpers/DateFormatters.swift
@@ -3,6 +3,7 @@
 //  
 //
 //  Created by Antoine van der Lee on 25/01/2022.
+//  Copyright © 2020 WeTransfer. All rights reserved.
 //
 
 import Foundation

--- a/Sources/GitBuddyCore/Helpers/Shell.swift
+++ b/Sources/GitBuddyCore/Helpers/Shell.swift
@@ -46,9 +46,11 @@ extension Process {
         let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
         guard let outputData = String(data: data, encoding: String.Encoding.utf8) else { return "" }
 
-        return outputData.reduce("") { (result, value) in
-            return result + String(value)
-        }.trimmingCharacters(in: .whitespacesAndNewlines)
+        return outputData
+            .reduce("") { (result, value) in
+                return result + String(value)
+            }
+            .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }
 

--- a/Sources/GitBuddyCore/Helpers/Shell.swift
+++ b/Sources/GitBuddyCore/Helpers/Shell.swift
@@ -14,6 +14,7 @@ enum ShellCommand {
     case previousTag
     case repositoryName
     case tagCreationDate(tag: String)
+    case commitDate(commitish: String)
 
     var rawValue: String {
         switch self {
@@ -27,6 +28,8 @@ enum ShellCommand {
             return "git remote show origin -n | ruby -ne 'puts /^\\s*Fetch.*(:|\\/){1}([^\\/]+\\/[^\\/]+).git/.match($_)[2] rescue nil'"
         case .tagCreationDate(let tag):
             return "git log -1 --format=%ai \(tag)"
+        case .commitDate(let commitish):
+            return "git show -s --format=%ai \(commitish)"
         }
     }
 }

--- a/Sources/GitBuddyCore/Models/Tag.swift
+++ b/Sources/GitBuddyCore/Models/Tag.swift
@@ -46,11 +46,6 @@ struct Tag: ShellInjectable, Encodable {
 
             Log.debug("Tag \(name) is created at \(tagCreationDate)")
 
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
-            dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-            dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
-
             guard let date = Formatter.gitDateFormatter.date(from: tagCreationDate) else {
                 throw Error.missingTagCreationDate
             }

--- a/Sources/GitBuddyCore/Models/Tag.swift
+++ b/Sources/GitBuddyCore/Models/Tag.swift
@@ -51,7 +51,7 @@ struct Tag: ShellInjectable, Encodable {
             dateFormatter.locale = Locale(identifier: "en_US_POSIX")
             dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
 
-            guard let date = dateFormatter.date(from: tagCreationDate) else {
+            guard let date = Formatter.gitDateFormatter.date(from: tagCreationDate) else {
                 throw Error.missingTagCreationDate
             }
             self.created = date

--- a/Tests/GitBuddyTests/TestHelpers/Mocks.swift
+++ b/Tests/GitBuddyTests/TestHelpers/Mocks.swift
@@ -25,6 +25,12 @@ struct MockedShell: ShellExecuting {
         commandMocks[command.rawValue] = value
     }
 
+    static func mockCommitish(_ commitish: String, date: Date = Date()) {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
+        commandMocks[ShellCommand.commitDate(commitish: commitish).rawValue] = dateFormatter.string(from: date)
+    }
+
     static func mockRelease(tag: String, date: Date = Date()) {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"

--- a/Tests/GitBuddyTests/TestHelpers/Mocks.swift
+++ b/Tests/GitBuddyTests/TestHelpers/Mocks.swift
@@ -5,7 +5,7 @@
 //  Created by Antoine van der Lee on 10/01/2020.
 //  Copyright © 2020 WeTransfer. All rights reserved.
 //
-//  danger:disable final_class
+// swiftlint:disable final_class
 
 import Foundation
 import Mocker


### PR DESCRIPTION
In scenarios where a `tagName` was provided, but no `changelogToTag` we changed the code to throw an `Error.changelogTargetDateMissing`.

However, there's another scenario that we did not solve here:

- When creating a release from a target commitish, we only provide a `tagName` to use for the to be created tag. The `changelogToTag` in this case is the `targetCommitish` date

We did not support this correctly, so I added another fallback to fetch the date using the target commitish.