### PR TITLE
Filter emojis out of changelog

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "GitBuddy",
     platforms: [
         .macOS(.v10_15)
-        ],
+    ],
     products: [
         .executable(name: "GitBuddy", targets: ["GitBuddy"])
     ],

--- a/Sources/GitBuddyCore/Changelog/ChangelogItemsFactory.swift
+++ b/Sources/GitBuddyCore/Changelog/ChangelogItemsFactory.swift
@@ -21,7 +21,7 @@ struct ChangelogItemsFactory {
                 return [ChangelogItem(input: pullRequest, closedBy: pullRequest)]
             }
             return resolvedIssues.map { issue -> ChangelogItem in
-                return ChangelogItem(input: issue, closedBy: pullRequest)
+                ChangelogItem(input: issue, closedBy: pullRequest)
             }
         }
     }

--- a/Sources/GitBuddyCore/Changelog/ChangelogProducer.swift
+++ b/Sources/GitBuddyCore/Changelog/ChangelogProducer.swift
@@ -11,14 +11,14 @@ import OctoKit
 
 /// Capable of producing a changelog based on input parameters.
 final class ChangelogProducer: URLSessionInjectable {
-
     enum Since {
         case date(date: Date)
         case tag(tag: String)
         case latestTag
 
         /// Gets the date for the current Since property.
-        /// In the case of a tag, we add 60 seconds to make sure that the Changelog does not include the commit that is used for creating the tag.
+        /// In the case of a tag, we add 60 seconds to make sure that the Changelog does not include the commit that
+        /// is used for creating the tag.
         /// This is needed as the tag creation date equals the commit creation date.
         func get() throws -> Date {
             switch self {
@@ -32,7 +32,7 @@ final class ChangelogProducer: URLSessionInjectable {
         }
     }
 
-    private lazy var octoKit: Octokit = Octokit()
+    private lazy var octoKit: Octokit = .init()
     let baseBranch: Branch
     let since: Since
     let from: Date

--- a/Sources/GitBuddyCore/Commands/ChangelogCommand.swift
+++ b/Sources/GitBuddyCore/Commands/ChangelogCommand.swift
@@ -5,11 +5,10 @@
 //  Created by Antoine van der Lee on 09/04/2020.
 //
 
-import Foundation
 import ArgumentParser
+import Foundation
 
 struct ChangelogCommand: ParsableCommand {
-
     public static let configuration = CommandConfiguration(commandName: "changelog", abstract: "Create a changelog for GitHub repositories")
 
     @Option(name: .shortAndLong, help: "The tag to use as a base. Defaults to the latest tag.")

--- a/Sources/GitBuddyCore/Commands/GitBuddy.swift
+++ b/Sources/GitBuddyCore/Commands/GitBuddy.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2020 WeTransfer. All rights reserved.
 //
 
-import Foundation
 import ArgumentParser
+import Foundation
 
 /// Entry class of GitBuddy that registers commands and handles execution.
 public struct GitBuddy: ParsableCommand {
@@ -20,5 +20,5 @@ public struct GitBuddy: ParsableCommand {
         subcommands: [ChangelogCommand.self, ReleaseCommand.self, TagDeletionsCommand.self]
     )
 
-    public init() { }
+    public init() {}
 }

--- a/Sources/GitBuddyCore/Commands/ReleaseCommand.swift
+++ b/Sources/GitBuddyCore/Commands/ReleaseCommand.swift
@@ -5,12 +5,14 @@
 //  Created by Antoine van der Lee on 09/04/2020.
 //
 
-import Foundation
 import ArgumentParser
+import Foundation
 
 struct ReleaseCommand: ParsableCommand {
-
-    public static let configuration = CommandConfiguration(commandName: "release", abstract: "Create a new release including a changelog and publish comments on related issues.")
+    public static let configuration = CommandConfiguration(
+        commandName: "release",
+        abstract: "Create a new release including a changelog and publish comments on related issues."
+    )
 
     @Option(name: .shortAndLong, help: "The path to the Changelog to update it with the latest changes.")
     var changelogPath: String?
@@ -22,11 +24,26 @@ struct ReleaseCommand: ParsableCommand {
     var isPrerelease: Bool = false
 
     // Main
-    @Option(name: .shortAndLong, help: "Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists. Default: the repository's default branch (usually main).")
+    @Option(
+        name: .shortAndLong,
+        help: """
+            Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA.
+            Unused if the Git tag already exists.
+
+            Default: the repository's default branch (usually main).
+        """
+    )
     var targetCommitish: String?
 
     // 1.3.1b1072
-    @Option(name: [.long, .customShort("n")], help: "The name of the tag. If set, `changelogToTag` is required too. Default: takes the last created tag to publish as a GitHub release.")
+    @Option(
+        name: [.long, .customShort("n")],
+        help: """
+            The name of the tag. If set, `changelogToTag` is required too.
+
+            Default: takes the last created tag to publish as a GitHub release.
+        """
+    )
     var tagName: String?
 
     // // 1.3.1b1072 - App Store Release
@@ -37,7 +54,15 @@ struct ReleaseCommand: ParsableCommand {
     @Option(name: .shortAndLong, help: "The last release tag to use as a base for the changelog creation. Default: previous tag.")
     var lastReleaseTag: String?
 
-    @Option(name: .customLong("changelogToTag"), help: "If set, the date of this tag will be used as the limit for the changelog creation. This variable should be passed when `tagName` is set. Default: latest tag.")
+    @Option(
+        name: .customLong("changelogToTag"),
+        help: """
+            If set, the date of this tag will be used as the limit for the changelog creation.
+            This variable should be passed when `tagName` is set.
+
+            Default: latest tag.
+            """
+    )
     var changelogToTag: String?
 
     // Develop

--- a/Sources/GitBuddyCore/Commands/ReleaseCommand.swift
+++ b/Sources/GitBuddyCore/Commands/ReleaseCommand.swift
@@ -21,21 +21,26 @@ struct ReleaseCommand: ParsableCommand {
     @Flag(name: [.customLong("use-pre-release"), .customShort("p")], help: "Create the release as a pre-release.")
     var isPrerelease: Bool = false
 
+    // Main
     @Option(name: .shortAndLong, help: "Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists. Default: the repository's default branch (usually main).")
     var targetCommitish: String?
 
+    // 1.3.1b1072
     @Option(name: [.long, .customShort("n")], help: "The name of the tag. If set, `changelogToTag` is required too. Default: takes the last created tag to publish as a GitHub release.")
     var tagName: String?
 
+    // // 1.3.1b1072 - App Store Release
     @Option(name: .shortAndLong, help: "The title of the release. Default: uses the tag name.")
     var releaseTitle: String?
 
+    // 1.3.0b1039
     @Option(name: .shortAndLong, help: "The last release tag to use as a base for the changelog creation. Default: previous tag.")
     var lastReleaseTag: String?
 
     @Option(name: .customLong("changelogToTag"), help: "If set, the date of this tag will be used as the limit for the changelog creation. This variable should be passed when `tagName` is set. Default: latest tag.")
     var changelogToTag: String?
 
+    // Develop
     @Option(name: .shortAndLong, help: "The base branch to compare with for generating the changelog. Defaults to master.")
     var baseBranch: String?
 

--- a/Sources/GitBuddyCore/Commands/TagDeletionsCommand.swift
+++ b/Sources/GitBuddyCore/Commands/TagDeletionsCommand.swift
@@ -1,9 +1,11 @@
-import Foundation
 import ArgumentParser
+import Foundation
 
 struct TagDeletionsCommand: ParsableCommand {
-
-    public static let configuration = CommandConfiguration(commandName: "tagDeletion", abstract: "Delete a batch of tags based on given predicates.")
+    public static let configuration = CommandConfiguration(
+        commandName: "tagDeletion",
+        abstract: "Delete a batch of tags based on given predicates."
+    )
 
     @Option(name: .shortAndLong, help: "The date of this tag will be used as a limit. Defaults to the latest tag.")
     private var upUntilTag: String?

--- a/Sources/GitBuddyCore/GitHub/Commenter.swift
+++ b/Sources/GitBuddyCore/GitHub/Commenter.swift
@@ -18,8 +18,10 @@ enum Comment {
         case .releasedPR(let release):
             return "Congratulations! :tada: This was released as part of [Release \(release.title)](\(release.url)) :rocket:"
         case .releasedIssue(let release, let pullRequestID):
-            var body = "The pull request #\(pullRequestID) that closed this issue was merged and released as part of [Release \(release.title)](\(release.url)) :rocket:\n"
-            body += "Please let us know if the functionality works as expected as a reply here. If it does not, please open a new issue. Thanks!"
+            var body = "The pull request #\(pullRequestID) that closed this issue was merged and released "
+            body += "as part of [Release \(release.title)](\(release.url)) :rocket:\n"
+            body += "Please let us know if the functionality works as expected as a reply here. "
+            body += "If it does not, please open a new issue. Thanks!"
             return body
         }
     }
@@ -43,14 +45,17 @@ enum Commenter {
     static func post(_ comment: Comment, on issueID: Int, at project: GITProject, completion: @escaping () -> Void) {
         var body = comment.body
         body += watermark
-        Octokit().commentIssue(urlSession, owner: project.organisation, repository: project.repository, number: issueID, body: body) { response in
-            switch response {
-            case .success(let comment):
-                Log.debug("Successfully posted comment at: \(comment.htmlURL)")
-            case .failure(let error):
-                Log.debug("Posting comment for issue #\(issueID) failed: \(error)")
+        Octokit()
+            .commentIssue(urlSession, owner: project.organisation, repository: project.repository, number: issueID,
+                          body: body)
+            { response in
+                switch response {
+                case .success(let comment):
+                    Log.debug("Successfully posted comment at: \(comment.htmlURL)")
+                case .failure(let error):
+                    Log.debug("Posting comment for issue #\(issueID) failed: \(error)")
+                }
+                completion()
             }
-            completion()
-        }
     }
 }

--- a/Sources/GitBuddyCore/GitHub/IssuesFetcher.swift
+++ b/Sources/GitBuddyCore/GitHub/IssuesFetcher.swift
@@ -9,7 +9,6 @@ import Foundation
 import OctoKit
 
 struct IssuesFetcher {
-
     let octoKit: Octokit
     let project: GITProject
 
@@ -20,7 +19,7 @@ struct IssuesFetcher {
 
         var result: Result<[Issue], Swift.Error>!
 
-        octoKit.issues(session, owner: project.organisation, repository: project.repository, state: .closed) { (response) in
+        octoKit.issues(session, owner: project.organisation, repository: project.repository, state: .closed) { response in
             switch response {
             case .success(let issues):
                 result = .success(issues)
@@ -42,5 +41,4 @@ struct IssuesFetcher {
             return closedAt > fromDate && closedAt < toDate
         }
     }
-
 }

--- a/Sources/GitBuddyCore/GitHub/IssuesResolver.swift
+++ b/Sources/GitBuddyCore/GitHub/IssuesResolver.swift
@@ -42,7 +42,6 @@ struct IssuesResolver {
 }
 
 extension String {
-
     /// Extracts the resolved issues from a Pull Request body.
     func resolvingIssues() -> [Int] {
         var resolvedIssues = Set<Int>()
@@ -69,8 +68,8 @@ extension String {
                     guard index + 1 <= splits.count - 1 else { break }
                     let nextSplit = splits[index + 1]
 
-                    let numberPrefixString = nextSplit.prefix { (character) -> Bool in
-                        return character.isNumber
+                    let numberPrefixString = nextSplit.prefix { character -> Bool in
+                        character.isNumber
                     }
 
                     if !numberPrefixString.isEmpty, let numberPrefix = Int(numberPrefixString.description) {

--- a/Sources/GitBuddyCore/GitHub/OctoKit+Authentication.swift
+++ b/Sources/GitBuddyCore/GitHub/OctoKit+Authentication.swift
@@ -9,7 +9,6 @@ import Foundation
 import OctoKit
 
 extension Octokit {
-
     static var protocolClasses: [AnyClass]?
     static var environment: [String: String] = ProcessInfo.processInfo.environment
 

--- a/Sources/GitBuddyCore/GitHub/PullRequestFetcher.swift
+++ b/Sources/GitBuddyCore/GitHub/PullRequestFetcher.swift
@@ -12,7 +12,6 @@ import OctoKit
 typealias Branch = String
 
 struct PullRequestFetcher {
-
     let octoKit: Octokit
     let baseBranch: Branch
     let project: GITProject
@@ -23,7 +22,15 @@ struct PullRequestFetcher {
 
         var result: Result<[PullRequest], Swift.Error>!
 
-        octoKit.pullRequests(session, owner: project.organisation, repository: project.repository, base: baseBranch, state: .closed, sort: .updated, direction: .desc) { (response) in
+        octoKit.pullRequests(
+            session,
+            owner: project.organisation,
+            repository: project.repository,
+            base: baseBranch,
+            state: .closed,
+            sort: .updated,
+            direction: .desc
+        ) { response in
             switch response {
             case .success(let pullRequests):
                 result = .success(pullRequests)
@@ -39,5 +46,4 @@ struct PullRequestFetcher {
             return mergedAt > fromDate && mergedAt < toDate
         }
     }
-
 }

--- a/Sources/GitBuddyCore/Helpers/DateFormatters.swift
+++ b/Sources/GitBuddyCore/Helpers/DateFormatters.swift
@@ -1,6 +1,6 @@
 //
 //  DateFormatters.swift
-//  
+//
 //
 //  Created by Antoine van der Lee on 25/01/2022.
 //  Copyright © 2020 WeTransfer. All rights reserved.

--- a/Sources/GitBuddyCore/Helpers/DependencyInjectors.swift
+++ b/Sources/GitBuddyCore/Helpers/DependencyInjectors.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Adds a `urlSession` property which defaults to `URLSession.shared`.
-protocol URLSessionInjectable { }
+protocol URLSessionInjectable {}
 
 extension URLSessionInjectable {
     var urlSession: URLSession { return URLSessionInjector.urlSession }

--- a/Sources/GitBuddyCore/Helpers/Shell.swift
+++ b/Sources/GitBuddyCore/Helpers/Shell.swift
@@ -47,8 +47,8 @@ extension Process {
         guard let outputData = String(data: data, encoding: String.Encoding.utf8) else { return "" }
 
         return outputData
-            .reduce("") { (result, value) in
-                return result + String(value)
+            .reduce("") { result, value in
+                result + String(value)
             }
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }
@@ -65,7 +65,7 @@ private enum Shell: ShellExecuting {
 }
 
 /// Adds a `shell` property which defaults to `Shell.self`.
-protocol ShellInjectable { }
+protocol ShellInjectable {}
 
 extension ShellInjectable {
     static var shell: ShellExecuting.Type { ShellInjector.shell }

--- a/Sources/GitBuddyCore/Models/Changelog.swift
+++ b/Sources/GitBuddyCore/Models/Changelog.swift
@@ -28,7 +28,7 @@ struct SingleSectionChangelog: Changelog {
 
     init(items: [ChangelogItem]) {
         description = ChangelogBuilder(items: items).build()
-        self.itemIdentifiers = items.reduce(into: [:], { (result, item) in
+        itemIdentifiers = items.reduce(into: [:]) { result, item in
             let pullRequestID: PullRequestID = item.closedBy.number
 
             if var pullRequestIssues = result[pullRequestID] {
@@ -40,7 +40,7 @@ struct SingleSectionChangelog: Changelog {
             } else {
                 result[pullRequestID] = []
             }
-        })
+        }
     }
 }
 
@@ -63,7 +63,7 @@ struct SectionedChangelog: Changelog {
             \(ChangelogBuilder(items: pullRequests.map { ChangelogItem(input: $0, closedBy: $0) }).build())
             """
 
-        itemIdentifiers = pullRequests.reduce(into: [:]) { (result, item) in
+        itemIdentifiers = pullRequests.reduce(into: [:]) { result, item in
             result[item.number] = item.body?.resolvingIssues()
         }
     }

--- a/Sources/GitBuddyCore/Models/Changelog.swift
+++ b/Sources/GitBuddyCore/Models/Changelog.swift
@@ -50,7 +50,7 @@ struct SectionedChangelog: Changelog {
     let description: String
 
     let itemIdentifiers: [PullRequestID: [IssueID]]
-    
+
     init(issues: [Issue], pullRequests: [PullRequest]) {
         description =
             """

--- a/Sources/GitBuddyCore/Models/ChangelogItem.swift
+++ b/Sources/GitBuddyCore/Models/ChangelogItem.swift
@@ -16,8 +16,9 @@ protocol ChangelogInput {
     var htmlURL: Foundation.URL? { get }
     var username: String? { get }
 }
-protocol ChangelogIssue: ChangelogInput { }
-protocol ChangelogPullRequest: ChangelogInput { }
+
+protocol ChangelogIssue: ChangelogInput {}
+protocol ChangelogPullRequest: ChangelogInput {}
 
 extension PullRequest: ChangelogPullRequest {
     var username: String? { user?.login ?? assignee?.login }

--- a/Sources/GitBuddyCore/Models/ChangelogItem.swift
+++ b/Sources/GitBuddyCore/Models/ChangelogItem.swift
@@ -35,7 +35,7 @@ struct ChangelogItem {
         guard var title = input.title else { return nil }
         title = title.prefix(1).uppercased() + title.dropFirst()
         title = title.removingEmojis().trimmingCharacters(in: .whitespaces)
-        
+
         if let htmlURL = input.htmlURL {
             title += " ([#\(input.number)](\(htmlURL)))"
         }

--- a/Sources/GitBuddyCore/Models/ChangelogItem.swift
+++ b/Sources/GitBuddyCore/Models/ChangelogItem.swift
@@ -34,6 +34,8 @@ struct ChangelogItem {
     var title: String? {
         guard var title = input.title else { return nil }
         title = title.prefix(1).uppercased() + title.dropFirst()
+        title = title.removingEmojis().trimmingCharacters(in: .whitespaces)
+        
         if let htmlURL = input.htmlURL {
             title += " ([#\(input.number)](\(htmlURL)))"
         }
@@ -41,5 +43,13 @@ struct ChangelogItem {
             title += " via [@\(username)](https://github.com/\(username))"
         }
         return title
+    }
+}
+
+private extension String {
+    func removingEmojis() -> String {
+        String(unicodeScalars.filter {
+            !$0.properties.isEmojiPresentation
+        })
     }
 }

--- a/Sources/GitBuddyCore/Models/Tag.swift
+++ b/Sources/GitBuddyCore/Models/Tag.swift
@@ -21,7 +21,6 @@ struct Tag: ShellInjectable, Encodable {
                 return "There's no tags available"
             }
         }
-
     }
 
     let name: String
@@ -30,7 +29,8 @@ struct Tag: ShellInjectable, Encodable {
     /// Creates a new Tag instance.
     /// - Parameters:
     ///   - name: The name to use for the tag.
-    ///   - created: The creation date to use. If `nil`, the date is fetched using the `git` terminal command. See `fallbackDate` for setting a date if this operation fails due to a missing tag.
+    ///   - created: The creation date to use. If `nil`, the date is fetched using the `git` terminal command. See `fallbackDate`
+    ///   for setting a date if this operation fails due to a missing tag.
     /// - Throws: An error if the creation date could not be found.
     init(name: String, created: Date? = nil) throws {
         self.name = name

--- a/Sources/GitBuddyCore/Models/Token.swift
+++ b/Sources/GitBuddyCore/Models/Token.swift
@@ -47,5 +47,4 @@ struct Token: CustomStringConvertible {
         self.username = String(username)
         self.accessToken = String(accessToken)
     }
-
 }

--- a/Sources/GitBuddyCore/Tag Deletions/TagsDeleter.swift
+++ b/Sources/GitBuddyCore/Tag Deletions/TagsDeleter.swift
@@ -2,8 +2,7 @@ import Foundation
 import OctoKit
 
 final class TagsDeleter: URLSessionInjectable, ShellInjectable {
-
-    private lazy var octoKit: Octokit = Octokit()
+    private lazy var octoKit: Octokit = .init()
     let upUntilTagName: String?
     let limit: Int
     let prereleaseOnly: Bool
@@ -49,12 +48,12 @@ final class TagsDeleter: URLSessionInjectable, ShellInjectable {
         Log.debug("Fetched releases: \(releases.map { $0.tagName }.joined(separator: ", "))")
 
         return releases
-            .filter({ release in
+            .filter { release in
                 guard !prereleaseOnly || release.prerelease else {
                     return false
                 }
                 return release.createdAt < upUntil
-            })
+            }
             .suffix(limit)
     }
 
@@ -103,7 +102,12 @@ final class TagsDeleter: URLSessionInjectable, ShellInjectable {
                 return
             }
 
-            octoKit.deleteReference(urlSession, owner: project.organisation, repository: project.repository, ref: "tags/\(release.tagName)") { error in
+            octoKit.deleteReference(
+                urlSession,
+                owner: project.organisation,
+                repository: project.repository,
+                ref: "tags/\(release.tagName)"
+            ) { error in
                 defer { group.leave() }
                 guard let error = error else {
                     Log.debug("Successfully deleted tag \(release.tagName)")

--- a/Tests/GitBuddyTests/Changelog/ChangelogCommandTests.swift
+++ b/Tests/GitBuddyTests/Changelog/ChangelogCommandTests.swift
@@ -5,13 +5,12 @@
 //  Created by Antoine van der Lee on 09/04/2020.
 //
 
-import XCTest
-import Mocker
 @testable import GitBuddyCore
+import Mocker
 import OctoKit
+import XCTest
 
 final class ChangelogCommandTests: XCTestCase {
-
     override func setUp() {
         super.setUp()
         Octokit.protocolClasses = [MockingURLProtocol.self]
@@ -36,7 +35,10 @@ final class ChangelogCommandTests: XCTestCase {
         let token = "username:79B02BE4-38D1-4E3D-9B41-4E0739761512"
         mockGITAuthentication(token)
         try executeCommand("gitbuddy changelog")
-        XCTAssertEqual(URLSessionInjector.urlSession.configuration.httpAdditionalHeaders?["Authorization"] as? String, "Basic dXNlcm5hbWU6NzlCMDJCRTQtMzhEMS00RTNELTlCNDEtNEUwNzM5NzYxNTEy")
+        XCTAssertEqual(
+            URLSessionInjector.urlSession.configuration.httpAdditionalHeaders?["Authorization"] as? String,
+            "Basic dXNlcm5hbWU6NzlCMDJCRTQtMzhEMS00RTNELTlCNDEtNEUwNzM5NzYxNTEy"
+        )
     }
 
     /// It should correctly output the changelog.
@@ -99,7 +101,7 @@ final class ChangelogCommandTests: XCTestCase {
     /// It should use the latest tag by default for the latest release adding 60 seconds to its creation date.
     func testLatestReleaseUsingLatestTag() throws {
         let tag = "2.1.3"
-        let date = Date().addingTimeInterval(TimeInterval.random(in: 0..<100))
+        let date = Date().addingTimeInterval(TimeInterval.random(in: 0 ..< 100))
         MockedShell.mockRelease(tag: tag, date: date)
 
         let producer = try ChangelogProducer(baseBranch: nil)
@@ -109,11 +111,11 @@ final class ChangelogCommandTests: XCTestCase {
     /// It should use a tag passed as argument over the latest tag adding 60 seconds to its creation date..
     func testReleaseUsingTagArgument() throws {
         let expectedTag = "3.0.2"
-        let date = Date().addingTimeInterval(TimeInterval.random(in: 0..<100))
+        let date = Date().addingTimeInterval(TimeInterval.random(in: 0 ..< 100))
         MockedShell.mockRelease(tag: expectedTag, date: date)
 
         let producer = try ChangelogProducer(since: .tag(tag: expectedTag), baseBranch: nil)
-        guard case let ChangelogProducer.Since.tag(tag) = producer.since else {
+        guard case ChangelogProducer.Since.tag(let tag) = producer.since else {
             XCTFail("Wrong since used")
             return
         }
@@ -131,5 +133,4 @@ final class ChangelogCommandTests: XCTestCase {
         XCTAssertEqual(producer.project.organisation, organisation)
         XCTAssertEqual(producer.project.repository, repository)
     }
-
 }

--- a/Tests/GitBuddyTests/Changelog/ChangelogItemsFactoryTests.swift
+++ b/Tests/GitBuddyTests/Changelog/ChangelogItemsFactoryTests.swift
@@ -6,14 +6,13 @@
 //  Copyright © 2020 WeTransfer. All rights reserved.
 //
 
-import XCTest
 @testable import GitBuddyCore
-@testable import OctoKit
 import Mocker
+@testable import OctoKit
+import XCTest
 
 final class ChangelogItemsFactoryTests: XCTestCase {
-
-    private let octoKit: Octokit = Octokit()
+    private let octoKit: Octokit = .init()
     private var urlSession: URLSession!
     private let project = GITProject(organisation: "WeTransfer", repository: "Diagnostics")
 
@@ -51,5 +50,4 @@ final class ChangelogItemsFactoryTests: XCTestCase {
         XCTAssertEqual(items.first?.input.title, issue.title)
         XCTAssertEqual(items.first?.closedBy.title, pullRequest.title)
     }
-
 }

--- a/Tests/GitBuddyTests/GitBuddyCommandTests.swift
+++ b/Tests/GitBuddyTests/GitBuddyCommandTests.swift
@@ -6,11 +6,10 @@
 //  Copyright © 2020 WeTransfer. All rights reserved.
 //
 
-import XCTest
 @testable import GitBuddyCore
+import XCTest
 
 final class GitBuddyCommandTests: XCTestCase {
-
     /// It should throw an error if the GitHub access token was not set.
     func testMissingAccessToken() {
         do {

--- a/Tests/GitBuddyTests/GitHub/CommenterTests.swift
+++ b/Tests/GitBuddyTests/GitHub/CommenterTests.swift
@@ -5,12 +5,11 @@
 //  Created by Antoine van der Lee on 09/04/2020.
 //
 
-import XCTest
 @testable import GitBuddyCore
 import Mocker
+import XCTest
 
 final class CommenterTests: XCTestCase {
-
     override func setUp() {
         super.setUp()
         let configuration = URLSessionConfiguration.default
@@ -28,11 +27,21 @@ final class CommenterTests: XCTestCase {
     func testWatermark() throws {
         Mocker.mockPullRequests()
         let latestTag = try Tag.latest()
-        let release = Release(tagName: latestTag.name, url: URL(string: "https://www.fakegithub.com")!, title: "Release title", changelog: "")
+        let release = Release(
+            tagName: latestTag.name,
+            url: URL(string: "https://www.fakegithub.com")!,
+            title: "Release title",
+            changelog: ""
+        )
         let project = GITProject(organisation: "WeTransfer", repository: "GitBuddy")
 
         let mockExpectation = expectation(description: "Mock should be called")
-        var mock = Mock(url: URL(string: "https://api.github.com/repos/WeTransfer/GitBuddy/issues/1/comments")!, dataType: .json, statusCode: 200, data: [.post: Data()])
+        var mock = Mock(
+            url: URL(string: "https://api.github.com/repos/WeTransfer/GitBuddy/issues/1/comments")!,
+            dataType: .json,
+            statusCode: 200,
+            data: [.post: Data()]
+        )
         mock.onRequest = { _, postBodyArguments in
             let body = postBodyArguments?["body"] as? String
             XCTAssertTrue(body?.contains(Commenter.watermark) == true)

--- a/Tests/GitBuddyTests/GitHub/IssueResolverTests.swift
+++ b/Tests/GitBuddyTests/GitHub/IssueResolverTests.swift
@@ -62,7 +62,7 @@ final class IssueResolverTests: XCTestCase {
             "Resolves",
             "resolved"
         ]
-        
+
         let issueNumber = 4343
 
         issueClosingKeywords.forEach { (closingKeyword) in
@@ -70,13 +70,13 @@ final class IssueResolverTests: XCTestCase {
             XCTAssertEqual(description.resolvingIssues(), [issueNumber])
         }
     }
-    
+
     /// It should not extract anything if no issue number is found.
     func testResolvingNoReferencedIssue() {
         let description = examplePullRequestDescriptionUsing(closingKeyword: "fixes", issueNumber: nil)
         XCTAssertTrue(description.resolvingIssues().isEmpty)
     }
-    
+
     /// It should not extract anything if no closing keyword is found.
     func testResolvingNoClosingKeyword() {
         let issueNumber = 4343
@@ -84,7 +84,7 @@ final class IssueResolverTests: XCTestCase {
         let description = examplePullRequestDescriptionUsing(closingKeyword: "", issueNumber: issueNumber)
         XCTAssertTrue(description.resolvingIssues().isEmpty)
     }
-    
+
     /// It should extract mulitple issues.
     func testResolvingMultipleIssues() {
         let description = "This is a beautiful PR that close #123 for real. It also fixes #1 and fixes #2"
@@ -92,31 +92,31 @@ final class IssueResolverTests: XCTestCase {
         XCTAssertEqual(resolvedIssues.count, 3)
         XCTAssertEqual(Set(description.resolvingIssues()), Set([123, 1, 2]))
     }
-    
+
     /// It should deduplicate if the same issue is closed multiple times.
     func testResolvingMultipleIssuesDedup() {
         let description = "This is a beautiful PR that close #123 for real. It also fixes #123"
         XCTAssertEqual(description.resolvingIssues(), [123])
     }
-    
+
     /// It should not extract anything if there is no number after the #.
     func testResolvingNoNumber() {
         let description = "This is a beautiful PR that close # for real."
         XCTAssertTrue(description.resolvingIssues().isEmpty)
     }
-    
+
     /// It should not extract anything if there is no number after the #, and it's at the end.
     func testResolvingNoNumberLast() {
         let description = "This is a beautiful PR that close #"
         XCTAssertTrue(description.resolvingIssues().isEmpty)
     }
-    
+
     /// It should extract the issue if it's first.
     func testResolvingIssueFirst() {
         let description = "Resolves #123. Yay!"
         XCTAssertEqual(description.resolvingIssues(), [123])
     }
-    
+
     /// It should extract the issue if it's the only thing present.
     func testResolvingIssueOnly() {
         let description = "Resolved #123"
@@ -127,7 +127,7 @@ final class IssueResolverTests: XCTestCase {
 extension IssueResolverTests {
     func examplePullRequestDescriptionUsing(closingKeyword: String, issueNumber: Int?) -> String {
         let issueNumberString = issueNumber?.description ?? ""
-        
+
         return """
             This PR does a lot of awesome stuff.
             It even closes some issues!

--- a/Tests/GitBuddyTests/GitHub/IssueResolverTests.swift
+++ b/Tests/GitBuddyTests/GitHub/IssueResolverTests.swift
@@ -6,14 +6,13 @@
 //  Copyright © 2020 WeTransfer. All rights reserved.
 //
 
-import XCTest
-import OctoKit
-import Mocker
 @testable import GitBuddyCore
+import Mocker
+import OctoKit
+import XCTest
 
 final class IssueResolverTests: XCTestCase {
-
-    private let octoKit: Octokit = Octokit()
+    private let octoKit: Octokit = .init()
     private var urlSession: URLSession!
 
     override func setUp() {
@@ -65,7 +64,7 @@ final class IssueResolverTests: XCTestCase {
 
         let issueNumber = 4343
 
-        issueClosingKeywords.forEach { (closingKeyword) in
+        issueClosingKeywords.forEach { closingKeyword in
             let description = examplePullRequestDescriptionUsing(closingKeyword: closingKeyword, issueNumber: issueNumber)
             XCTAssertEqual(description.resolvingIssues(), [issueNumber])
         }
@@ -129,12 +128,11 @@ extension IssueResolverTests {
         let issueNumberString = issueNumber?.description ?? ""
 
         return """
-            This PR does a lot of awesome stuff.
-            It even closes some issues!
-            Not #3737 though. This one is too hard.
+        This PR does a lot of awesome stuff.
+        It even closes some issues!
+        Not #3737 though. This one is too hard.
 
-            \(closingKeyword) #\(issueNumberString)
-            """
-
+        \(closingKeyword) #\(issueNumberString)
+        """
     }
 }

--- a/Tests/GitBuddyTests/GitHub/PullRequestFetcherTests.swift
+++ b/Tests/GitBuddyTests/GitHub/PullRequestFetcherTests.swift
@@ -36,7 +36,7 @@ final class PullRequestFetcherTests: XCTestCase {
         let fetcher = PullRequestFetcher(octoKit: octoKit, baseBranch: "master", project: project)
         let pullRequests = try fetcher.fetchAllBetween(release.created, and: Date(), using: urlSession)
         XCTAssertEqual(pullRequests.count, 2)
-        XCTAssertEqual(pullRequests[0].title, "Add charset utf-8 to html head 🫥")
+        XCTAssertEqual(pullRequests[0].title, "Add charset utf-8 to html head 😃")
         XCTAssertEqual(pullRequests[1].title, "Fix warning occurring in pod library because of importing style.css #trivial")
     }
 

--- a/Tests/GitBuddyTests/GitHub/PullRequestFetcherTests.swift
+++ b/Tests/GitBuddyTests/GitHub/PullRequestFetcherTests.swift
@@ -36,7 +36,7 @@ final class PullRequestFetcherTests: XCTestCase {
         let fetcher = PullRequestFetcher(octoKit: octoKit, baseBranch: "master", project: project)
         let pullRequests = try fetcher.fetchAllBetween(release.created, and: Date(), using: urlSession)
         XCTAssertEqual(pullRequests.count, 2)
-        XCTAssertEqual(pullRequests[0].title, "Add charset utf-8 to html head")
+        XCTAssertEqual(pullRequests[0].title, "Add charset utf-8 to html head 🫥")
         XCTAssertEqual(pullRequests[1].title, "Fix warning occurring in pod library because of importing style.css #trivial")
     }
 

--- a/Tests/GitBuddyTests/GitHub/PullRequestFetcherTests.swift
+++ b/Tests/GitBuddyTests/GitHub/PullRequestFetcherTests.swift
@@ -6,14 +6,13 @@
 //  Copyright © 2020 WeTransfer. All rights reserved.
 //
 
-import XCTest
-import OctoKit
-import Mocker
 @testable import GitBuddyCore
+import Mocker
+import OctoKit
+import XCTest
 
 final class PullRequestFetcherTests: XCTestCase {
-
-    private let octoKit: Octokit = Octokit()
+    private let octoKit: Octokit = .init()
     private var urlSession: URLSession!
 
     override func setUp() {
@@ -39,5 +38,4 @@ final class PullRequestFetcherTests: XCTestCase {
         XCTAssertEqual(pullRequests[0].title, "Add charset utf-8 to html head 😃")
         XCTAssertEqual(pullRequests[1].title, "Fix warning occurring in pod library because of importing style.css #trivial")
     }
-
 }

--- a/Tests/GitBuddyTests/Models/ChangelogItemTests.swift
+++ b/Tests/GitBuddyTests/Models/ChangelogItemTests.swift
@@ -42,7 +42,7 @@ final class ChangelogItemTests: XCTestCase {
         let input = PullRequestsJSON.data(using: .utf8)!.mapJSON(to: [PullRequest].self).first!
         input.htmlURL = nil
         let item = ChangelogItem(input: input, closedBy: input)
-        XCTAssertEqual(item.title, "\(input.title!) via [@AvdLee](https://github.com/AvdLee)")
+        XCTAssertEqual(item.title, "Add charset utf-8 to html head via [@AvdLee](https://github.com/AvdLee)")
     }
 
     /// It should fallback to the assignee if the user is nil for Pull Requests.
@@ -53,7 +53,7 @@ final class ChangelogItemTests: XCTestCase {
         let item = ChangelogItem(input: input, closedBy: input)
         XCTAssertEqual(
             item.title,
-            "\(input.title!) via [@kairadiagne](https://github.com/kairadiagne)"
+            "Add charset utf-8 to html head via [@kairadiagne](https://github.com/kairadiagne)"
         )
     }
 

--- a/Tests/GitBuddyTests/Models/ChangelogItemTests.swift
+++ b/Tests/GitBuddyTests/Models/ChangelogItemTests.swift
@@ -6,12 +6,11 @@
 //  Copyright © 2020 WeTransfer. All rights reserved.
 //
 
-import XCTest
 @testable import GitBuddyCore
 import OctoKit
+import XCTest
 
 final class ChangelogItemTests: XCTestCase {
-
     /// It should return `nil` if there's no title.
     func testNilTitle() {
         let item = ChangelogItem(input: MockChangelogInput(), closedBy: MockedPullRequest())
@@ -67,5 +66,4 @@ final class ChangelogItemTests: XCTestCase {
             "\(input.title!) ([#1](https://www.fakeurl.com)) via [@Henk](https://github.com/Henk)"
         )
     }
-
 }

--- a/Tests/GitBuddyTests/Models/SingleSectionChangelogTests.swift
+++ b/Tests/GitBuddyTests/Models/SingleSectionChangelogTests.swift
@@ -7,11 +7,10 @@
 //
 
 import Foundation
-import XCTest
 @testable import GitBuddyCore
+import XCTest
 
 final class SingleSectionChangelogTests: XCTestCase {
-
     /// It should report a single issue from a pull request correctly.
     func testPullRequestSingleIssue() {
         let pullRequest = MockedPullRequest(number: 0)

--- a/Tests/GitBuddyTests/Release/ReleaseProducerTests.swift
+++ b/Tests/GitBuddyTests/Release/ReleaseProducerTests.swift
@@ -6,13 +6,12 @@
 //  Copyright © 2020 WeTransfer. All rights reserved.
 //
 
-import XCTest
 @testable import GitBuddyCore
 import Mocker
 import OctoKit
+import XCTest
 
 final class ReleaseProducerTests: XCTestCase {
-
     override func setUp() {
         super.setUp()
         Octokit.protocolClasses = [MockingURLProtocol.self]
@@ -38,7 +37,10 @@ final class ReleaseProducerTests: XCTestCase {
         let token = "username:79B02BE4-38D1-4E3D-9B41-4E0739761512"
         mockGITAuthentication(token)
         try executeCommand("gitbuddy release -s")
-        XCTAssertEqual(URLSessionInjector.urlSession.configuration.httpAdditionalHeaders?["Authorization"] as? String, "Basic dXNlcm5hbWU6NzlCMDJCRTQtMzhEMS00RTNELTlCNDEtNEUwNzM5NzYxNTEy")
+        XCTAssertEqual(
+            URLSessionInjector.urlSession.configuration.httpAdditionalHeaders?["Authorization"] as? String,
+            "Basic dXNlcm5hbWU6NzlCMDJCRTQtMzhEMS00RTNELTlCNDEtNEUwNzM5NzYxNTEy"
+        )
     }
 
     /// It should correctly output the release URL.
@@ -48,6 +50,7 @@ final class ReleaseProducerTests: XCTestCase {
 
     func testReleaseOutputJSON() throws {
         let output = try executeCommand("gitbuddy release -s --json")
+        // swiftlint:disable:next line_length
         XCTAssertTrue(output.contains("{\"title\":\"1.0.1\",\"tagName\":\"1.0.1\",\"url\":\"https:\\/\\/github.com\\/WeTransfer\\/ChangelogProducer\\/releases\\/tag\\/1.0.1\""))
     }
 

--- a/Tests/GitBuddyTests/Tag Deletions/TagsDeleterTests.swift
+++ b/Tests/GitBuddyTests/Tag Deletions/TagsDeleterTests.swift
@@ -1,17 +1,16 @@
 //
 //  TagsDeleterTests.swift
-//  
+//
 //
 //  Created by Antoine van der Lee on 25/01/2022.
 //
 
-import XCTest
 @testable import GitBuddyCore
 import Mocker
 import OctoKit
+import XCTest
 
 final class TagsDeleterTests: XCTestCase {
-
     override func setUp() {
         super.setUp()
         Octokit.protocolClasses = [MockingURLProtocol.self]

--- a/Tests/GitBuddyTests/TestHelpers/IssueJSON.swift
+++ b/Tests/GitBuddyTests/TestHelpers/IssueJSON.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2020 WeTransfer. All rights reserved.
 //
 
+// swiftlint:disable line_length
 let IssueJSON = """
 
 {

--- a/Tests/GitBuddyTests/TestHelpers/IssuesJSON.swift
+++ b/Tests/GitBuddyTests/TestHelpers/IssuesJSON.swift
@@ -5,6 +5,8 @@
 //  Created by Max Desiatov on 28/03/2020.
 //
 
+// swiftlint:disable line_length
+// swiftlint:disable file_length
 let IssuesJSON = #"""
 [
   {

--- a/Tests/GitBuddyTests/TestHelpers/IssuesJSON.swift
+++ b/Tests/GitBuddyTests/TestHelpers/IssuesJSON.swift
@@ -777,7 +777,7 @@ let IssuesJSON = #"""
     "id": 545013288,
     "node_id": "MDExOlB1bGxSZXF1ZXN0MzU5MDA1MjAz",
     "number": 50,
-    "title": "Add charset utf-8 to html head",
+    "title": "Add charset utf-8 to html head 🫥",
     "user": {
       "login": "intitni",
       "id": 793147,

--- a/Tests/GitBuddyTests/TestHelpers/IssuesJSON.swift
+++ b/Tests/GitBuddyTests/TestHelpers/IssuesJSON.swift
@@ -777,7 +777,7 @@ let IssuesJSON = #"""
     "id": 545013288,
     "node_id": "MDExOlB1bGxSZXF1ZXN0MzU5MDA1MjAz",
     "number": 50,
-    "title": "Add charset utf-8 to html head 🫥",
+    "title": "Add charset utf-8 to html head 😃",
     "user": {
       "login": "intitni",
       "id": 793147,

--- a/Tests/GitBuddyTests/TestHelpers/ListReleasesJSON.swift
+++ b/Tests/GitBuddyTests/TestHelpers/ListReleasesJSON.swift
@@ -1,6 +1,6 @@
 //
 //  ListReleasesJSON.swift
-//  
+//
 //
 //  Created by Antoine van der Lee on 25/01/2022.
 //

--- a/Tests/GitBuddyTests/TestHelpers/Mocks.swift
+++ b/Tests/GitBuddyTests/TestHelpers/Mocks.swift
@@ -8,13 +8,12 @@
 // swiftlint:disable final_class
 
 import Foundation
+@testable import GitBuddyCore
 import Mocker
 import OctoKit
-@testable import GitBuddyCore
 import XCTest
 
 struct MockedShell: ShellExecuting {
-
     static var commandMocks: [String: String] = [:]
 
     @discardableResult static func execute(_ command: ShellCommand) -> String {
@@ -59,8 +58,8 @@ class MockChangelogInput: ChangelogInput {
     }
 }
 
-final class MockedPullRequest: MockChangelogInput, ChangelogPullRequest { }
-final class MockedIssue: MockChangelogInput, ChangelogIssue { }
+final class MockedPullRequest: MockChangelogInput, ChangelogPullRequest {}
+final class MockedIssue: MockChangelogInput, ChangelogIssue {}
 
 extension Mocker {
     static func mockPullRequests(baseBranch: String = "master") {
@@ -69,7 +68,10 @@ extension Mocker {
         let date = dateFormatter.date(from: "2020-01-03")!
         MockedShell.mockRelease(tag: "1.0.0", date: date)
 
-        var urlComponents = URLComponents(url: URL(string: "https://api.github.com/repos/WeTransfer/Diagnostics/pulls")!, resolvingAgainstBaseURL: false)!
+        var urlComponents = URLComponents(
+            url: URL(string: "https://api.github.com/repos/WeTransfer/Diagnostics/pulls")!,
+            resolvingAgainstBaseURL: false
+        )!
         urlComponents.queryItems = [
             URLQueryItem(name: "base", value: baseBranch),
             URLQueryItem(name: "direction", value: "desc"),
@@ -88,7 +90,10 @@ extension Mocker {
         let date = dateFormatter.date(from: "2020-01-03")!
         MockedShell.mockRelease(tag: "1.0.0", date: date)
 
-        var urlComponents = URLComponents(url: URL(string: "https://api.github.com/repos/WeTransfer/Diagnostics/issues")!, resolvingAgainstBaseURL: false)!
+        var urlComponents = URLComponents(
+            url: URL(string: "https://api.github.com/repos/WeTransfer/Diagnostics/issues")!,
+            resolvingAgainstBaseURL: false
+        )!
         urlComponents.queryItems = [
             URLQueryItem(name: "page", value: "1"),
             URLQueryItem(name: "per_page", value: "100"),
@@ -108,26 +113,46 @@ extension Mocker {
 
     @discardableResult static func mockRelease() -> Mock {
         let releaseJSONData = ReleaseJSON.data(using: .utf8)!
-        let mock = Mock(url: URL(string: "https://api.github.com/repos/WeTransfer/Diagnostics/releases")!, dataType: .json, statusCode: 201, data: [.post: releaseJSONData])
+        let mock = Mock(
+            url: URL(string: "https://api.github.com/repos/WeTransfer/Diagnostics/releases")!,
+            dataType: .json,
+            statusCode: 201,
+            data: [.post: releaseJSONData]
+        )
         mock.register()
         return mock
     }
 
     @discardableResult static func mockListReleases() -> Mock {
         let releaseJSONData = ListReleasesJSON.data(using: .utf8)!
-        let mock = Mock(url: URL(string: "https://api.github.com/repos/WeTransfer/Diagnostics/releases?per_page=100")!, dataType: .json, statusCode: 200, data: [.get: releaseJSONData])
+        let mock = Mock(
+            url: URL(string: "https://api.github.com/repos/WeTransfer/Diagnostics/releases?per_page=100")!,
+            dataType: .json,
+            statusCode: 200,
+            data: [.get: releaseJSONData]
+        )
         mock.register()
         return mock
     }
 
     @discardableResult static func mockDeletingRelease(id: Int) -> Mock {
-        let mock = Mock(url: URL(string: "https://api.github.com/repos/WeTransfer/Diagnostics/releases/\(id)")!, dataType: .json, statusCode: 204, data: [.delete: Data()])
+        let mock = Mock(
+            url: URL(string: "https://api.github.com/repos/WeTransfer/Diagnostics/releases/\(id)")!,
+            dataType: .json,
+            statusCode: 204,
+            data: [.delete: Data()]
+        )
         mock.register()
         return mock
     }
 
     @discardableResult static func mockDeletingReference(tagName: String) -> Mock {
-        let mock = Mock(url: URL(string: "https://api.github.com/repos/WeTransfer/Diagnostics/git/refs/tags/\(tagName)")!, dataType: .json, statusCode: 204, data: [.delete: Data()])
+        let mock = Mock(
+            url: URL(string: "https://api.github.com/repos/WeTransfer/Diagnostics/git/refs/tags/\(tagName)")!,
+            dataType: .json,
+            statusCode: 204,
+            data: [.delete: Data()]
+        )
         mock.register()
         return mock
     }

--- a/Tests/GitBuddyTests/TestHelpers/PullRequestsJSON.swift
+++ b/Tests/GitBuddyTests/TestHelpers/PullRequestsJSON.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+// swiftlint:disable line_length
 let PullRequestsJSON = """
 
 [{

--- a/Tests/GitBuddyTests/TestHelpers/PullRequestsJSON.swift
+++ b/Tests/GitBuddyTests/TestHelpers/PullRequestsJSON.swift
@@ -21,7 +21,7 @@ let PullRequestsJSON = """
         "number": 50,
         "state": "closed",
         "locked": false,
-        "title": "Add charset utf-8 to html head",
+        "title": "Add charset utf-8 to html head 🫥",
         "user": {
             "login": "AvdLee",
             "id": 793147,

--- a/Tests/GitBuddyTests/TestHelpers/PullRequestsJSON.swift
+++ b/Tests/GitBuddyTests/TestHelpers/PullRequestsJSON.swift
@@ -21,7 +21,7 @@ let PullRequestsJSON = """
         "number": 50,
         "state": "closed",
         "locked": false,
-        "title": "Add charset utf-8 to html head 🫥",
+        "title": "Add charset utf-8 to html head 😃",
         "user": {
             "login": "AvdLee",
             "id": 793147,

--- a/Tests/GitBuddyTests/TestHelpers/ReleaseJSON.swift
+++ b/Tests/GitBuddyTests/TestHelpers/ReleaseJSON.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+// swiftlint:disable line_length
 let ReleaseJSON = """
 
 {

--- a/Tests/GitBuddyTests/TestHelpers/XCTestExtensions.swift
+++ b/Tests/GitBuddyTests/TestHelpers/XCTestExtensions.swift
@@ -6,12 +6,13 @@
 //
 
 import Foundation
-import XCTest
 @testable import GitBuddyCore
+import XCTest
 
 extension XCTest {
-
-    func AssertEqualStringsIgnoringTrailingWhitespace(_ string1: String, _ string2: String, file: StaticString = #file, line: UInt = #line) {
+    func AssertEqualStringsIgnoringTrailingWhitespace(_ string1: String, _ string2: String, file: StaticString = #file,
+                                                      line: UInt = #line)
+    {
         let lines1 = string1.split(separator: "\n", omittingEmptySubsequences: false)
         let lines2 = string2.split(separator: "\n", omittingEmptySubsequences: false)
 
@@ -23,7 +24,8 @@ extension XCTest {
 
     /// Executes the command and throws the execution error if any occur.
     /// - Parameters:
-    ///   - command: The command to execute. This command can be exactly the same as you would use in the terminal. E.g. "gitbuddy changelog".
+    ///   - command: The command to execute. This command can be exactly the same as you would use in the terminal.
+    ///   E.g. "gitbuddy changelog".
     ///   - expected: The expected outcome printed in the console.
     /// - Throws: The error occured while executing the command.
     func AssertExecuteCommand(_ command: String, expected: String, file: StaticString = #file, line: UInt = #line) throws {
@@ -51,7 +53,7 @@ extension XCTest {
 
 extension Substring {
     func trimmed() -> Substring {
-        guard let i = lastIndex(where: { $0 != " "}) else {
+        guard let i = lastIndex(where: { $0 != " " }) else {
             return ""
         }
         return self[...i]

--- a/Tests/GitBuddyTests/XCTestManifests.swift
+++ b/Tests/GitBuddyTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-public func allTests() -> [XCTestCaseEntry] {
-    return [
-        // testCase(GitBuddyTests.allTests),
-    ]
-}
-#endif


### PR DESCRIPTION
Emojis can break systems like App Store Connect, so it's safer to keep them out by default. I decided to not make it an option or flag since that will require more work now and it's questionable how much it will be used.