### PR TITLE
Improve error logs for GitBuddy GitHub API failures

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/nerdishbynature/RequestKit.git",
         "state": {
           "branch": null,
-          "revision": "e266fd8ac7d71caf4422ffc56ad98ff368329fde",
-          "version": "3.1.0"
+          "revision": "8b0258ea2a4345cbcac90509b764faacea12efb0",
+          "version": "3.2.1"
         }
       },
       {

--- a/Sources/GitBuddyCore/GitHub/IssuesFetcher.swift
+++ b/Sources/GitBuddyCore/GitHub/IssuesFetcher.swift
@@ -24,7 +24,7 @@ struct IssuesFetcher {
             case .success(let issues):
                 result = .success(issues)
             case .failure(let error):
-                result = .failure(error)
+                result = .failure(OctoKitError(error: error))
             }
             group.leave()
         }

--- a/Sources/GitBuddyCore/GitHub/PullRequestFetcher.swift
+++ b/Sources/GitBuddyCore/GitHub/PullRequestFetcher.swift
@@ -35,7 +35,7 @@ struct PullRequestFetcher {
             case .success(let pullRequests):
                 result = .success(pullRequests)
             case .failure(let error):
-                result = .failure(error)
+                result = .failure(OctoKitError(error: error))
             }
             group.leave()
         }

--- a/Sources/GitBuddyCore/Helpers/OctoKitError.swift
+++ b/Sources/GitBuddyCore/Helpers/OctoKitError.swift
@@ -1,0 +1,28 @@
+//
+//  Created by Antoine van der Lee on 20/10/2022.
+//  Copyright © 2022 WeTransfer. All rights reserved.
+//
+
+import Foundation
+
+/// Ensures rich details become available when GitBuddy fails due to a failing GitHub API request.
+struct OctoKitError: LocalizedError {
+
+    let statusCode: Int
+    let underlyingError: Error
+    let errorDetails: String
+
+    var errorDescription: String? {
+        """
+        GitHub API Request failed (StatusCode: \(statusCode)): \(errorDetails)
+        Underlying error:
+        \(underlyingError)
+        """
+    }
+
+    init(error: Error) {
+        underlyingError = error
+        statusCode = error._code
+        errorDetails = (error as NSError).userInfo.debugDescription
+    }
+}

--- a/Sources/GitBuddyCore/Release/ReleaseProducer.swift
+++ b/Sources/GitBuddyCore/Release/ReleaseProducer.swift
@@ -207,7 +207,7 @@ final class ReleaseProducer: URLSessionInjectable, ShellInjectable {
             case .success(let release):
                 result = .success(release.htmlURL)
             case .failure(let error):
-                result = .failure(error)
+                result = .failure(OctoKitError(error: error))
             }
             group.leave()
         }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,8 +1,8 @@
 # Fastlane requirements
 fastlane_version "1.109.0"
 
-import "./../Submodules/WeTransfer-iOS-CI/Fastlane/Fastfile"
-import "./../Submodules/wetransfer-iOS-CI/Fastlane/shared_lanes.rb"
+import "./../Submodules/WeTransfer-iOS-CI/Fastlane/testing_lanes.rb"
+import "./../Submodules/WeTransfer-iOS-CI/Fastlane/shared_lanes.rb"
 
 desc "Run the tests and prepare for Danger"
 lane :test do |options|


### PR DESCRIPTION
Instead of:

> Exit status of command 'mint run --silent gitbuddy release -l 1.7.5b2622 -b develop --skip-comments --json --use-pre-release --target-commitish build/new-version/1.7.6 --tag-name 1.7.5b2623 --release-title '1.7.5b2623 - Beta'' was 1 instead of 0.
> Error: The operation couldn’t be completed. (com.nerdishbynature.octokit error 422.)

We will now get:

```
Error: GitHub API Request failed (StatusCode: 422): ["RequestKitErrorKey": ["message": Validation Failed, "documentation_url": https://docs.github.com/rest/reference/repos#create-a-release, "errors": <__NSArrayM 0x600001c9a970>(
{
    code = "already_exists";
    field = "tag_name";
    resource = Release;
}
)
]]
Underlying error:
Error Domain=com.nerdishbynature.octokit Code=422 "(null)" UserInfo={RequestKitErrorKey={
    "documentation_url" = "https://docs.github.com/rest/reference/repos#create-a-release";
    errors =     (
                {
            code = "already_exists";
            field = "tag_name";
            resource = Release;
        }
    );
    message = "Validation Failed";
}}
```
