### PR TITLE
Increase PR Limit to fetch 100 latest

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/WeTransfer/octokit.swift",
         "state": {
           "branch": "main",
-          "revision": "8f78b18b3278a378d9a96bd7b832ce4091378c5c",
+          "revision": "f20ac29a920aa8a7b36340d7f285a727e9b30d6e",
           "version": null
         }
       },

--- a/Sources/GitBuddyCore/GitHub/PullRequestFetcher.swift
+++ b/Sources/GitBuddyCore/GitHub/PullRequestFetcher.swift
@@ -29,7 +29,8 @@ struct PullRequestFetcher {
             base: baseBranch,
             state: .closed,
             sort: .updated,
-            direction: .desc
+            direction: .desc,
+            perPage: 100
         ) { response in
             switch response {
             case .success(let pullRequests):

--- a/Tests/GitBuddyTests/TestHelpers/Mocks.swift
+++ b/Tests/GitBuddyTests/TestHelpers/Mocks.swift
@@ -75,6 +75,7 @@ extension Mocker {
         urlComponents.queryItems = [
             URLQueryItem(name: "base", value: baseBranch),
             URLQueryItem(name: "direction", value: "desc"),
+            URLQueryItem(name: "per_page", value: "100"),
             URLQueryItem(name: "sort", value: "updated"),
             URLQueryItem(name: "state", value: "closed")
         ]


### PR DESCRIPTION
To make sure we include all PRs in our changelogs we're updating the limit from 30 (default) to 100